### PR TITLE
Socket txn handling

### DIFF
--- a/dev/configs/web-test-runner.config.mjs
+++ b/dev/configs/web-test-runner.config.mjs
@@ -6,7 +6,33 @@ export default {
   files: ['../src/components/**/*.test.*'],
   concurrentBrowsers: 1,
   concurrency: 2,
+  testFramework: {
+    config: {
+      timeout: 3000,
+      retries: 1
+    }
+  },
   browsers: [
+    // playwrightLauncher({ product: 'chromium' }),
     playwrightLauncher({ product: 'firefox' }),
-  ]
+    // playwrightLauncher({ product: 'webkit' })
+  ],
+  testRunnerHtml: testFramework => `
+    <html lang="en-US" class="sl-theme-dark">
+      <head>
+        <link rel="stylesheet" type="text/css" href="/vendor/@shoelace/cdn@2.14.0/themes/dark.css">
+      </head>
+      <body>
+        <script>
+          window.process = {env: { NODE_ENV: "production" }}
+        </script>
+        <script type="module" src="${testFramework}"></script>
+        <script type="module">
+          import { setBasePath } from '/vendor/@shoelace/cdn@2.14.0/utilities/base-path.js';
+          import '/vendor/@shoelace/cdn@2.14.0/shoelace.js';
+          setBasePath('/vendor/@shoelace/cdn@2.14.0/');
+        </script>
+      </body>
+    </html>
+  `,
 };

--- a/dev/configs/web-test-runner.config.mjs
+++ b/dev/configs/web-test-runner.config.mjs
@@ -1,11 +1,13 @@
 import { playwrightLauncher } from '@web/test-runner-playwright';
 
 export default {
-  nodeResolve: true,
   rootDir: '../src/',
   files: ['../src/components/**/*.test.*'],
   concurrentBrowsers: 1,
   concurrency: 2,
+  nodeResolve: {
+    exportConditions: ['production', 'default']
+  },
   testFramework: {
     config: {
       timeout: 3000,

--- a/dev/configs/web-test-runner.config.mjs
+++ b/dev/configs/web-test-runner.config.mjs
@@ -1,0 +1,12 @@
+import { playwrightLauncher } from '@web/test-runner-playwright';
+
+export default {
+  nodeResolve: true,
+  rootDir: '../src/',
+  files: ['../src/components/**/*.test.*'],
+  concurrentBrowsers: 1,
+  concurrency: 2,
+  browsers: [
+    playwrightLauncher({ product: 'firefox' }),
+  ]
+};

--- a/dev/package.json
+++ b/dev/package.json
@@ -7,7 +7,8 @@
     "setup": "./scripts/setup.sh",
     "check": "./scripts/check.sh",
     "start": "./scripts/check.sh && node ./example-pups/run.js & node ./scripts/start.js",
-    "test": "web-test-runner --config ./configs/web-test-runner.config.mjs"
+    "test": "web-test-runner --config ./configs/web-test-runner.config.mjs",
+    "test:watch": "web-test-runner --config ./configs/web-test-runner.config.mjs --watch"
   },
   "author": "",
   "license": "MIT",

--- a/dev/package.json
+++ b/dev/package.json
@@ -6,11 +6,16 @@
   "scripts": {
     "setup": "./scripts/setup.sh",
     "check": "./scripts/check.sh",
-    "start": "./scripts/check.sh && node ./example-pups/run.js & node ./scripts/start.js"
+    "start": "./scripts/check.sh && node ./example-pups/run.js & node ./scripts/start.js",
+    "test": "web-test-runner --config ./configs/web-test-runner.config.mjs"
   },
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@web/dev-server": "^0.4.3"
+    "@open-wc/testing": "^4.0.0",
+    "@web/dev-server": "^0.4.3",
+    "@web/test-runner": "^0.18.1",
+    "@web/test-runner-commands": "^0.9.0",
+    "@web/test-runner-playwright": "^0.11.0"
   }
 }

--- a/dev/package.json
+++ b/dev/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "devDependencies": {
     "@open-wc/testing": "^4.0.0",
-    "@web/dev-server": "^0.4.3",
+    "@web/dev-server": "^0.4.4",
     "@web/test-runner": "^0.18.1",
     "@web/test-runner-commands": "^0.9.0",
     "@web/test-runner-playwright": "^0.11.0"

--- a/dev/utils/keyboard.js
+++ b/dev/utils/keyboard.js
@@ -1,0 +1,8 @@
+import { sendKeys } from "../node_modules/@web/test-runner-commands"
+
+export async function repeatKeys(command, iterations = 1) {
+  if (!command) return
+  for (let i = 0; i < iterations; i++) {
+    await sendKeys(command);
+  }
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -30,12 +30,29 @@ export default class ApiClient {
     // Otherwise, perform the fetch request
     const url = new URL(path, this.baseURL).href;
     const headers = { 'Content-Type': 'application/json', ...config.headers };
+    let response, data
 
-    const response = await fetch(url, { ...config, headers });
-    const data = await response.json();
-    if (!response.ok) {
-      throw new Error(data.message || 'An error occurred while fetching data');
+    try {
+      response = await fetch(url, { ...config, headers });
+    } catch (fetchErr) {
+      throw new Error('An error occurred while fetching data, refer to network logs');
     }
+
+    if (response.status === 404) {
+      throw new Error(`Resource not found: ${url}`);
+    }
+
+    if (!response.ok) {
+      throw new Error('Fetching returned an unsuccessful response', { ok, status: repsonse.status });
+    }
+
+    try {
+      data = await response.json();
+    } catch (jsonParseErr) {
+      console.warn('Could not JSON parse response from server', jsonParseErr);
+      throw new Error('Could not JSON parse response from server');
+    }
+
     return data;
   }
 }

--- a/src/components/common/alert.js
+++ b/src/components/common/alert.js
@@ -1,8 +1,10 @@
-export function createAlert(variant, message, icon = 'info-circle', duration = 3000) {
+export function createAlert(variant, message, icon = 'info-circle', duration) {
   const alert = document.createElement('sl-alert');
   alert.variant = variant;
   alert.closable = true;
-  alert.duration = duration;
+  if (duration) {
+    alert.duration = duration;
+  }
   alert.innerHTML = `
     <sl-icon name="${icon}" slot="icon"></sl-icon>
     ${escapeHtml(message)}

--- a/src/components/common/alert.js
+++ b/src/components/common/alert.js
@@ -5,10 +5,20 @@ export function createAlert(variant, message, icon = 'info-circle', duration) {
   if (duration) {
     alert.duration = duration;
   }
-  alert.innerHTML = `
-    <sl-icon name="${icon}" slot="icon"></sl-icon>
-    ${escapeHtml(message)}
-  `;
+
+  if (Array.isArray(message)) {
+    const messageHtml = `<strong>${escapeHtml(message[0])}</strong>` + message.slice(1).map(item => `<br>${escapeHtml(item)}`).join('');
+    alert.innerHTML = `
+      <sl-icon name="${icon}" slot="icon"></sl-icon>
+      ${messageHtml}
+    `;
+  } else {
+    alert.innerHTML = `
+      <sl-icon name="${icon}" slot="icon"></sl-icon>
+      ${escapeHtml(message)}
+    `;
+  }
+
   document.body.append(alert);
   alert.toast();
 }

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -10,6 +10,7 @@ class DynamicForm extends LitElement {
       values: { type: Object },
       fields: { type: Object },
       onSubmit: { type: Object },
+      requireCommit: { type: Boolean },
       _activeFormId: { type: String, state: true },
       _dirty: { type: Number, state: true },
       _loading: { type: Boolean, state: true },
@@ -24,6 +25,7 @@ class DynamicForm extends LitElement {
     bindToClass(methods, this);
     this.values = {};
     this.fields = {};
+    this.requireCommit = false;
     this._activeFormId = null;
     this._dirty = 0;
     this._loading = false;
@@ -92,10 +94,6 @@ class DynamicForm extends LitElement {
 
   async updated(changedProperties) {
     await this._onUpdate(changedProperties);
-  }
-
-  disconnectedCallback() {
-    this._removeFormSubmitListeners();
   }
 }
 

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -2,6 +2,7 @@ import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import * as methods from '/components/common/dynamic-form/index.js';
 import { bindToClass } from '/utils/class-bind.js';
 import { styles } from './styles.js';
+import debounce from '/utils/debounce.js';
 
 class DynamicForm extends LitElement {
 
@@ -84,7 +85,7 @@ class DynamicForm extends LitElement {
     if (!this.fields?.sections) return;
 
     return html`
-      <sl-resize-observer @sl-resize=${this._handleResize}>
+      <sl-resize-observer @sl-resize=${debounce(this._handleResize, 300)}>
         <div class="dynamic-form-wrapper">
           ${this._generateOneOrManyForms(this.fields)}
         </div>

--- a/src/components/common/dynamic-form/lib/focus.js
+++ b/src/components/common/dynamic-form/lib/focus.js
@@ -1,0 +1,17 @@
+export function focus(fieldName) {
+  if (!fieldName) return
+  const node = this.shadowRoot.querySelector(`[name=${fieldName}`)
+
+  if (!node) {
+    console.warn(`field focus issue: ${fieldName} not found`)
+    return
+  }
+
+  if (!node || !node.focus || typeof node.focus !== 'function') {
+    console.warn(`field focus issue: focus method does not exist for ${fieldName}`);
+    return
+  }
+
+  console.log(`forcing focus to: ${fieldName}`);
+  node.focus();
+}

--- a/src/components/common/dynamic-form/lib/focus.js
+++ b/src/components/common/dynamic-form/lib/focus.js
@@ -12,6 +12,5 @@ export function focus(fieldName) {
     return
   }
 
-  console.log(`forcing focus to: ${fieldName}`);
   node.focus();
 }

--- a/src/components/common/dynamic-form/lib/index.js
+++ b/src/components/common/dynamic-form/lib/index.js
@@ -1,5 +1,6 @@
 export * from './diff.js';
 export * from './events.js';
+export * from './focus.js';
 export * from './handlers.js';
 export * from './on-update.js';
 export * from './props.js';

--- a/src/components/common/dynamic-form/lib/props.js
+++ b/src/components/common/dynamic-form/lib/props.js
@@ -10,15 +10,12 @@ export function _initializeFormFieldProperties(newValue) {
 
       // Create the standard property
       this.constructor.createProperty(currentKey, { type: String });
-      console.log('CREATED', currentKey);
 
       // Create the prefixed property (used for change tracking)
       this.constructor.createProperty(originalKey, { type: String });
-      console.log('CREATED', originalKey);
 
       // Create a property for dirty tracking
       this.constructor.createProperty(isDirtyKey, { type: Boolean });
-      console.log('CREATED', isDirtyKey);
     });
   });
 }

--- a/src/components/common/dynamic-form/renders/form.js
+++ b/src/components/common/dynamic-form/renders/form.js
@@ -23,7 +23,7 @@ export function _generateOneOrManyForms(data) {
 
   const form = (section, index = 0) => {
     const formFields = repeat(section.fields, (field) => field.name, (field) => this._generateField(field))
-    const formControls = this._generateFormControls({ formId: section.name, submitLabel: 'Peanut' })
+    const formControls = this._generateFormControls({ formId: section.name, submitLabel: 'Save' })
     return html`
       <form id=${section.name} @submit=${this._handleSubmit}>
         ${formFields}

--- a/src/components/common/dynamic-form/renders/form.js
+++ b/src/components/common/dynamic-form/renders/form.js
@@ -23,7 +23,7 @@ export function _generateOneOrManyForms(data) {
 
   const form = (section, index = 0) => {
     const formFields = repeat(section.fields, (field) => field.name, (field) => this._generateField(field))
-    const formControls = this._generateFormControls({ formId: section.name, submitLabel: 'Save' })
+    const formControls = this._generateFormControls({ formId: section.name, submitLabel: 'Peanut' })
     return html`
       <form id=${section.name} @submit=${this._handleSubmit}>
         ${formFields}

--- a/src/components/common/dynamic-form/tests/dynamic-form.test.js
+++ b/src/components/common/dynamic-form/tests/dynamic-form.test.js
@@ -1,0 +1,221 @@
+
+// import { html, fixture, expect, waitUntil } from "@open-wc/testing";
+import { html, fixture, expect, waitUntil, elementUpdated, aTimeout } from "../../../../../dev/node_modules/@open-wc/testing";
+import { sendKeys } from '../../../../../dev/node_modules/@web/test-runner-commands';
+import { ONE_OF_EACH_FIELD_TYPE } from "./fixtures/one_of_each_field_type.js";
+
+import "../dynamic-form.js";
+import { customElementsReady } from '/utils/custom-elements-ready.js';
+
+describe("DynamicForm", () => {
+
+  it('given a single section, should render a single form', async () => {
+
+    const fields = {
+      sections: [
+        { 
+          name: 'section-foo', 
+          fields: [
+            { name: 'first', label: 'First', type: 'text' }
+          ]
+        }
+      ]
+    }
+    
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const forms = el.shadowRoot.querySelectorAll('form')
+
+    expect(forms).to.exist;
+    expect(forms.length).to.equal(1);
+    expect(forms[0].id).to.equal('section-foo');
+  });
+
+  it('given multiple sections, should render a multiple forms', async () => {
+
+    const fields = {
+      sections: [
+        { 
+          name: 'section-foo', 
+          fields: [
+            { name: 'first', label: 'First', type: 'text' }
+          ]
+        },
+        { 
+          name: 'section-bar', 
+          fields: [
+            { name: 'dob', label: 'Date of birth', type: 'date' }
+          ]
+        }
+      ],
+
+    }
+    
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const forms = el.shadowRoot.querySelectorAll('form')
+
+    expect(forms).to.exist;
+    expect(forms.length).to.equal(2);
+    expect(forms[0].id).to.equal('section-foo');
+    expect(forms[1].id).to.equal('section-bar');
+  });
+
+  it('given a single field, should render field', async () => {
+
+    const fields = {
+      sections: [
+        { 
+          name: 'section-foo', 
+          fields: [
+            { name: 'first', label: 'First', type: 'text' }
+          ]
+        }
+      ]
+    }
+    
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+    const formControls = form.querySelectorAll('.form-control');
+    const formInput = form.querySelector('sl-input');
+    const formAttributeNames = formInput.getAttributeNames();
+
+    // Should be 1 form-control element
+    expect(formControls.length).to.equal(1);
+
+    // Input should have the correct type, name and label.
+    expect(formAttributeNames).to.deep.equal(['type', 'name', 'label'])
+    expect(formInput.getAttribute('type')).to.equal('text');
+    expect(formInput.getAttribute('name')).to.equal('first');
+    expect(formInput.getAttribute('label')).to.equal('First');
+  });
+
+  it('given a multiple fields (1 of each type), should render all (14) fields with the correct input control', async () => {
+
+    const fields = {
+      sections: [
+        { 
+          name: 'section-foo', 
+          fields: ONE_OF_EACH_FIELD_TYPE
+        }
+      ]
+    }
+    
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+    const formControls = form.querySelectorAll('.form-control');
+
+    // Should be 1 form-control element
+    expect(formControls.length).to.equal(14);
+    
+    // Expect correct shoelace component usage
+    const tags = [...formControls].map(c => c.children[0].tagName);
+    expect(tags).to.deep.equal([
+      'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT',
+      'SL-CHECKBOX', 'SL-SWITCH', 'SL-SELECT', 'SL-RADIO-GROUP', 'SL-RADIO-GROUP', 
+      'SL-TEXTAREA', 'SL-COLOR-PICKER', 'SL-RANGE', 'SL-RATING']);
+
+    // Expect correct type attribute set for the SL-INPUT (because it can be one of many)
+    const textInputs = [...formControls]
+      .filter(c => c.children[0].tagName === 'SL-INPUT')
+      .map(c => c.children[0].getAttribute('type')
+    )
+    expect(textInputs).to.deep.equal(['text', 'email', 'password', 'date', 'number']);
+
+    // Expect radios to reder correct sub type (sl-radio vs. sl-radio-button)
+    const radioInputs = [...formControls]
+      .filter(c => c.children[0].tagName === 'SL-RADIO-GROUP')
+      .map(c => c.children[0].children[0].tagName
+    )
+    expect(radioInputs).to.deep.equal(['SL-RADIO', 'SL-RADIO-BUTTON']);
+  });
+
+  it.skip('enables form submit button on field modification', async () => {
+    const fields = {
+      sections: [
+        { 
+          name: 'section-foo', 
+          fields: [
+            { name: 'first', label: 'First', type: 'text' }
+          ]
+        }
+      ]
+    }
+
+    const values = {
+      'first': 'Joe'
+    }
+    
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+        .values=${values}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+
+    const submitButton = el.shadowRoot.querySelector('sl-button[type=submit]');
+    const inputField = el.shadowRoot.querySelector('sl-input');
+
+    expect(form).to.exist;
+    expect(submitButton).to.exist;
+    expect(submitButton.hasAttribute('disabled')).to.be.true;
+    expect(inputField).to.exist;
+
+    // Set focus on field, using dynamic-form custom focus() method
+    el.focus('first');
+
+    // With the sl-input now in focus, type "hello"
+    // Todo.  Not working.
+    await sendKeys({ type: 'hello' });
+
+    await waitUntil(() => el._dirty, 'Form did not become modified');
+
+    // // Assert that submit button is no longer disabled
+    expect(submitButton.hasAttribute('disabled')).to.be.false;
+  });
+});

--- a/src/components/common/dynamic-form/tests/dynamic-form.test.js
+++ b/src/components/common/dynamic-form/tests/dynamic-form.test.js
@@ -4,7 +4,6 @@ import { sendKeys } from '../../../../../dev/node_modules/@web/test-runner-comma
 
 // Fixtures
 import { ONE_OF_EACH_FIELD_TYPE } from "./fixtures/one_of_each_field_type.js";
-import { ONE_FIELD_FIRSTNAME } from "./fixtures/one_field.js";
 
 // Component being tested.
 import "../dynamic-form.js";
@@ -168,111 +167,4 @@ describe("DynamicForm", () => {
     expect(radioInputs).to.deep.equal(['SL-RADIO', 'SL-RADIO-BUTTON']);
   });
 
-  it('fields are modified when as a user types', async () => {
-    const fields = ONE_FIELD_FIRSTNAME
-
-    // Initialise the component
-    const el = await fixture(html`
-      <dynamic-form
-        .fields=${fields}
-      ></dynamic-form>
-    `);
-
-    // Wait until fields are initialized
-    await waitUntil(() => el.values, 'Values did not become ready');
-
-    // Target input field
-    const inputField = el.shadowRoot.querySelector('sl-input');
-    // Set focus on field, using dynamic-form custom focus() method
-    el.focus('first');
-
-    // With the sl-input now in focus, type "hello"
-    await sendKeys({ type: 'hel' });
-    await waitUntil(() => el._first, 'Expected reactive property "_first" was not updated');
-    expect(el._first).to.equal('hel');
-
-    await sendKeys({ type: 'lo' });
-    await waitUntil(() => el._first, 'Expected reactive property "_first" was not updated');
-    expect(el._first).to.equal('hello');
-  });
-
-  it('the form is marked as dirty when a field is modified from its original state', async () => {
-    const fields = ONE_FIELD_FIRSTNAME
-
-    // Initialise the component
-    const el = await fixture(html`
-      <dynamic-form
-        .fields=${fields}
-      ></dynamic-form>
-    `);
-
-    // Wait until fields are initialized
-    await waitUntil(() => el.values, 'Values did not become ready');
-
-    // Target form
-    const inputField = el.shadowRoot.querySelector('sl-input');
-    expect(inputField).to.exist;
-
-    // Set focus on field, using dynamic-form custom focus() method
-    el.focus('first');
-
-    // With the sl-input now in focus, type "hello"
-    await sendKeys({ type: 'hello' });
-
-    await waitUntil(() => el._dirty, 'Form did not recognise modification and set dirty flag');
-
-    // // Assert that submit button is no longer disabled
-    expect(el._dirty).to.equal(1);
-  });
-
-  it('the submit button is initially disabled', async () => {
-    const fields = ONE_FIELD_FIRSTNAME
-
-    // Initialise the component    
-    const el = await fixture(html`
-      <dynamic-form
-        .fields=${fields}
-      ></dynamic-form>
-    `);
-
-    // Wait until fields are initialized
-    await waitUntil(() => el.values, 'Values did not become ready');
-
-    // Target form
-    const submitButton = el.shadowRoot.querySelector('sl-button[type=submit]');
-
-    expect(submitButton).to.exist;
-    expect(submitButton.hasAttribute('disabled')).to.be.true;
-  });
-
-  it('the submit button becomes enabled when a field is modified', async () => {
-    const fields = ONE_FIELD_FIRSTNAME
-
-    // Initialise the component
-    const el = await fixture(html`
-      <dynamic-form
-        .fields=${fields}
-      ></dynamic-form>
-    `);
-
-    // Wait until fields are initialized
-    await waitUntil(() => el.values, 'Values did not become ready');
-
-    // Target form
-    const submitButton = el.shadowRoot.querySelector('sl-button[type=submit]');
-
-    expect(submitButton).to.exist;
-    expect(submitButton.hasAttribute('disabled')).to.be.true;
-
-    // Set focus on field, using dynamic-form custom focus() method
-    el.focus('first');
-
-    // With the sl-input now in focus, type "hello"
-    await sendKeys({ type: 'hello' });
-
-    await waitUntil(() => el._dirty, 'Form did not recognise modification and set dirty flag');
-
-    // // Assert that submit button is no longer disabled
-    expect(submitButton.hasAttribute('disabled')).to.be.false;
-  });
 });

--- a/src/components/common/dynamic-form/tests/fixtures/one_field.js
+++ b/src/components/common/dynamic-form/tests/fixtures/one_field.js
@@ -1,0 +1,10 @@
+export const ONE_FIELD_FIRSTNAME = {
+  sections: [
+    { 
+      name: 'section-foo', 
+      fields: [
+        { name: 'first', label: 'First', type: 'text' }
+      ]
+    }
+  ]
+}

--- a/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
+++ b/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
@@ -36,7 +36,7 @@ export const ONE_OF_EACH_FIELD_TYPE = [
   // Color
   { name: 'bannerColour', label: 'Banner Colour', type: 'color' },
   // Range
-  { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
+  // { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
   // Rating
   { name: 'score', label: 'Score (out of 5)', type: 'rating' },
 ]

--- a/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
+++ b/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
@@ -1,0 +1,42 @@
+export const ONE_OF_EACH_FIELD_TYPE = [
+  // Text (sl-input)
+  { name: 'displayName', label: 'Display name', type: 'text' },
+  // Email (sl-input)
+  { name: 'emailAddress', label: 'Email address', type: 'email' },
+  // Password (sl-input)
+  { name: 'password', label: 'Password', type: 'password' },
+  // Date (sl-input)
+  { name: 'dob', label: 'Date of birth', type: 'date' },
+  // Number (sl-input)
+  { name: 'lucky_number', label: 'Lucky number?', type: 'number' },
+  // Checkbox (sl-checkbox)
+  { name: 'enableAwesome', label: 'Enable awesome?', type: 'checkbox' },
+  // Toggle (sl-switch)
+  { name: 'enableExtraAwesome', label: 'Enable extra awesome?', type: 'toggle' },
+  // Select (sl-select)
+  { name: 'fave_color', label: 'Favourite colour?', type: 'select', options: [
+    { name: 'blue', label: 'Blue' },
+    { name: 'green', label: 'Green' },
+    { name: 'red', label: 'Red' }]
+  },
+  // Radio (sl-radio-group)
+  { name: 'fave_cuisine', label: 'Favourite cuisine?', type: 'radio', options: [
+    { name: 'italian', label: 'Italian' },
+    { name: 'mexican', label: 'Mexican' },
+    { name: 'asian', label: 'Asian' }]
+  },
+  // Radio Button (sl-radio-group)
+  { name: 'fave_music_genre', label: 'Favourite music genre?', type: 'radioButton', options: [
+    { name: 'classical', label: 'Classical' },
+    { name: 'jazz', label: 'Jazz' },
+    { name: 'rock', label: 'Rock' }]
+  },
+  // Textarea
+  { name: 'bio', label: 'Bio', type: 'textarea' },
+  // Color
+  { name: 'bannerColour', label: 'Banner Colour', type: 'color' },
+  // Range
+  { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
+  // Rating
+  { name: 'score', label: 'Score (out of 5)', type: 'rating' },
+]

--- a/src/components/common/dynamic-form/tests/fixtures/three_fields.js
+++ b/src/components/common/dynamic-form/tests/fixtures/three_fields.js
@@ -1,0 +1,12 @@
+export const THREE_FIELDS_FIRST_MIDDLE_LAST = {
+  sections: [
+    { 
+      name: 'section-foo', 
+      fields: [
+        { name: 'first', label: 'First', type: 'text' },
+        { name: 'middle', label: 'Middle', type: 'text' },
+        { name: 'last', label: 'Last', type: 'text' }
+      ]
+    }
+  ]
+}

--- a/src/components/common/dynamic-form/tests/form.onchange.test.js
+++ b/src/components/common/dynamic-form/tests/form.onchange.test.js
@@ -1,0 +1,198 @@
+// Test helpers
+import { html, fixture, expect, waitUntil, elementUpdated, aTimeout } from "../../../../../dev/node_modules/@open-wc/testing";
+import { sendKeys } from '../../../../../dev/node_modules/@web/test-runner-commands';
+import { repeatKeys } from '../../../../../dev/utils/keyboard.js';
+
+// Fixtures
+import { ONE_FIELD_FIRSTNAME } from "./fixtures/one_field.js";
+import { THREE_FIELDS_FIRST_MIDDLE_LAST } from "./fixtures/three_fields.js";
+
+// Component being tested.
+import "../dynamic-form.js";
+
+describe("DynamicForm", () => {
+
+  it('fields are modified when as a user types', async () => {
+    const fields = ONE_FIELD_FIRSTNAME
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target input field
+    const inputField = el.shadowRoot.querySelector('sl-input');
+    // Set focus on field, using dynamic-form custom focus() method
+    el.focus('first');
+
+    // With the sl-input now in focus, type "hello"
+    await sendKeys({ type: 'hel' });
+    await waitUntil(() => el._first, 'Expected reactive property "_first" was not updated');
+    expect(el._first).to.equal('hel');
+
+    await sendKeys({ type: 'lo' });
+    await waitUntil(() => el._first, 'Expected reactive property "_first" was not updated');
+    expect(el._first).to.equal('hello');
+  });
+
+  it('the form is marked as dirty when a field is modified from its original state', async () => {
+    const fields = ONE_FIELD_FIRSTNAME
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const inputField = el.shadowRoot.querySelector('sl-input');
+    expect(inputField).to.exist;
+
+    // Set focus on field, using dynamic-form custom focus() method
+    el.focus('first');
+
+    // With the sl-input now in focus, type "hello"
+    await sendKeys({ type: 'hello' });
+    await waitUntil(() => el._dirty, 'Form did not recognise modification and set dirty flag');
+
+    // // Assert that submit button is no longer disabled
+    expect(el._dirty).to.equal(1);
+  });
+
+  it('the _dirty count matches the number of modified fields', async () => {
+    const fields = THREE_FIELDS_FIRST_MIDDLE_LAST;
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Expect incrememnt
+    el.focus('first');
+    await sendKeys({ type: 'John' });
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(1);
+
+    el.focus('middle');
+    await sendKeys({ type: 'Joseph' });
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(2);
+
+    el.focus('last');
+    await sendKeys({ type: 'Travolta' });
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(3);
+
+    // Expect decrement
+    el.focus('first');
+    await repeatKeys({ press: 'Backspace' }, 5);
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(2);
+
+    el.focus('middle');
+    await repeatKeys({ press: 'Backspace' }, 7);
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(1);
+
+    el.focus('last');
+    await repeatKeys({ press: 'Backspace' }, 9);
+    await elementUpdated(el);
+    expect(el._dirty).to.equal(0);
+  });
+
+  it('further modifications to an already modified field do not increment/decrement the _dirty field count', async () => {
+    const fields = THREE_FIELDS_FIRST_MIDDLE_LAST;
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Expect incrememnt
+    el.focus('first');
+    await sendKeys({ type: 'John' });
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(1);
+
+    el.focus('middle');
+    await sendKeys({ type: 'Jo'});
+    await waitUntil(() => el._dirty);
+    expect(el._dirty).to.equal(2);
+
+    await sendKeys({ type: 'seph' });
+    await elementUpdated(el);
+    // dirty field count should remain at 2.
+    expect(el._dirty).to.equal(2);
+
+  });
+
+  it('the submit button is initially disabled', async () => {
+    const fields = ONE_FIELD_FIRSTNAME
+
+    // Initialise the component    
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const submitButton = el.shadowRoot.querySelector('sl-button[type=submit]');
+
+    expect(submitButton).to.exist;
+    expect(submitButton.hasAttribute('disabled')).to.be.true;
+  });
+
+  it('the submit button becomes enabled when a field is modified', async () => {
+    const fields = ONE_FIELD_FIRSTNAME
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const submitButton = el.shadowRoot.querySelector('sl-button[type=submit]');
+
+    expect(submitButton).to.exist;
+    expect(submitButton.hasAttribute('disabled')).to.be.true;
+
+    // Set focus on field, using dynamic-form custom focus() method
+    el.focus('first');
+
+    // With the sl-input now in focus, type "hello"
+    await sendKeys({ type: 'hello' });
+    await waitUntil(() => el._dirty, 'Form did not recognise modification and set dirty flag');
+
+    // // Assert that submit button is no longer disabled
+    expect(submitButton.hasAttribute('disabled')).to.be.false;
+  });
+});
+

--- a/src/components/views/pup-snapshot/pup-snapshot.js
+++ b/src/components/views/pup-snapshot/pup-snapshot.js
@@ -106,25 +106,30 @@ class PupSnapshot extends LitElement {
     }
   }
 
-  submitPupConfigChanges = async (data, callbacks) => {
-    console.log('submitPupConfigChanges CALLED', this.pupId);
+  submitConfig = async (stagedChanges, formNode, dynamicForm) => {
+    // prepare callbacks
+    const callbacks = {
+      onSuccess: () => dynamicForm.commitChanges(formNode),
+      onError: (errorPayload) => {
+        // To cease the form from spinning
+        dynamicForm.retainChanges();
+        // Display a failure banner
+        this.displayConfigUpdateErr(errorPayload)
+      }
+    }
 
-    // UP TO HERE, requestPupChanges not expecting callbacks to be an object yet.
-    const res = await pkgController.requestPupChanges(this.pupId, data, callbacks); // <-- !! HERE.
+    // invoke pkgContrller model update, supplying data and callbacks
+    const res = await pkgController.requestPupChanges(this.pupId, stagedChanges, callbacks);
 
-    console.log('GOT TO HERE', { res });
-    // Return truth if successful.
     if (res && !res.error) {
       return true;
     }
   }
 
-  displayTxnFailAlert(failedTxnPayload) {
-    createAlert('danger', `
-      Sad doge. Failed to save changes (see console for logs).`,
-      'exclamation-diamond'
-    );
-    console.warn('Sad doge.', failedTxnPayload)
+  displayConfigUpdateErr(failedTxnPayload) {
+    const failedTxnId = failedTxnPayload?.id ? `(${failedTxnPayload.id})` : '';
+    createAlert('danger', ['Failed to update Pup configuration', `Refer to logs ${failedTxnId}`], 'exclamation-diamond');
+    console.warn(`Doge is sad because ${failedTxnId}: `, failedTxnPayload)
   }
 
   handleTabClick(event) {

--- a/src/components/views/pup-snapshot/pup-snapshot.js
+++ b/src/components/views/pup-snapshot/pup-snapshot.js
@@ -9,6 +9,7 @@ import '/components/views/log-viewer/log-viewer.js'
 import * as mockConfig from '/components/common/dynamic-form/mocks/index.js'
 import { pkgController } from '/controllers/package/index.js';
 import { postConfig } from '/api/config/config.js';
+import { createAlert } from '/components/common/alert.js';
 
 // Import component chunks
 import * as renderMethods from './renders/index.js';
@@ -69,7 +70,7 @@ class PupSnapshot extends LitElement {
     super.connectedCallback();
     this.pkgController.addObserver(this);
     this.addEventListener('form-dirty-change', this.handleDirtyChange.bind(this), { composed: true })
-    this.addEventListener('form-submit-success', this.handleFormSubmitSuccess.bind(this), { composed: true })
+    this.addEventListener('form-submit-success', this.handlePupUpdateSuccess.bind(this), { composed: true })
   }
 
   firstUpdated() {
@@ -81,7 +82,7 @@ class PupSnapshot extends LitElement {
 
   disconnectedCallback() {
     this.removeEventListener('form-dirty-change', this.handleDirtyChange.bind(this))
-    this.removeEventListener('form-submit-success', this.handleFormSubmitSuccess.bind(this), { composed: true })
+    this.removeEventListener('form-submit-success', this.handlePupUpdateSuccess.bind(this), { composed: true })
     this.pkgController.removeObserver(this);
     super.disconnectedCallback();
   }
@@ -90,21 +91,40 @@ class PupSnapshot extends LitElement {
     this._dirty = event.detail.dirty;
   }
 
-  async handleFormSubmitSuccess(event) {
+  async handlePupUpdateSuccess() {
+    // Celebrate successful update of pup config.
     this._saved = true;
     await asyncTimeout(2000)
     this._saved = false;
   }
 
-  submitPupConfigChanges = async (data) => {
-    const res = await postConfig(this.pupId, data);
-    await pkgController.savePupChanges(this.pupId, data);
-    // Updated PupSnapshots copy of options
-    // This will trigger a re-render of the dynamic-form
-    await asyncTimeout(4000);
+  async handlePupConfigSubmitResponse(res) {
+    console.log('handlePupConfigSubmitResponse CALLED', res);
+    if (!res || res.error) {
+      console.log('handlePupConfigSubmitResponse massive error', { res });
+      return;
+    }
+  }
 
-    console.log('--injecting new state returned from server');
-    this.options = { ...this.options, ...data }
+  submitPupConfigChanges = async (data, callbacks) => {
+    console.log('submitPupConfigChanges CALLED', this.pupId);
+
+    // UP TO HERE, requestPupChanges not expecting callbacks to be an object yet.
+    const res = await pkgController.requestPupChanges(this.pupId, data, callbacks); // <-- !! HERE.
+
+    console.log('GOT TO HERE', { res });
+    // Return truth if successful.
+    if (res && !res.error) {
+      return true;
+    }
+  }
+
+  displayTxnFailAlert(failedTxnPayload) {
+    createAlert('danger', `
+      Sad doge. Failed to save changes (see console for logs).`,
+      'exclamation-diamond'
+    );
+    console.warn('Sad doge.', failedTxnPayload)
   }
 
   handleTabClick(event) {

--- a/src/components/views/pup-snapshot/renders/section_config.js
+++ b/src/components/views/pup-snapshot/renders/section_config.js
@@ -19,8 +19,9 @@ export function renderSectionConfig() {
           <dynamic-form
             .values=${this.options}
             .fields=${this.config}
-            .onSubmit=${this.submitPupConfigChanges}
-            .onError=${this.displayTxnFailAlert}
+            .onSubmit=${this.submitConfig}
+            .onError=${this.displayConfigUpdateErr}
+            requireCommit
           >
           </dynamic-form>
         `)}

--- a/src/components/views/pup-snapshot/renders/section_config.js
+++ b/src/components/views/pup-snapshot/renders/section_config.js
@@ -20,6 +20,7 @@ export function renderSectionConfig() {
             .values=${this.options}
             .fields=${this.config}
             .onSubmit=${this.submitPupConfigChanges}
+            .onError=${this.displayTxnFailAlert}
           >
           </dynamic-form>
         `)}

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -100,18 +100,20 @@ class PkgController {
 
     // Txn failed, invoke error callback.
     if (!payload || payload.error) {
-      console.warn('txn contained error', { txn, payload });
-      foundAction.callbacks.onError(payload).catch((err) => {
-        console.warn('pkgController: ERROR CALLBACK ENCOUNTERED AN ERROR', err);
-      });
+      try {
+        foundAction.callbacks.onError(payload);
+      } catch (err) {
+        console.warn('the provided onError callback function threw an error');
+      }
       return;
     }
 
     // Txn succeeded, invoke success callback.
-    console.log('Proceeding to call registered action onSuccess callback');
-    foundAction.callbacks.onSuccess(payload).catch((err) => {
-      console.warn('pkgController: SUCCESS CALLBACK ENCOUNTERED AN ERROR', err);
-    })
+    try {
+      foundAction.callbacks.onSuccess(payload);
+    } catch (err) {
+      console.warn('the provided onSuccess callback function threw an error');
+    }
 
     switch (foundAction.actionType) {
       case 'UPDATE-PUP':
@@ -129,8 +131,6 @@ class PkgController {
     //   this.installed[installedIndex] = { ...installedPup, ...newData };
     // }
 
-    console.log('UPDATE PUP MODEL CALLED WITH', { pupId, newPupStateData });
-
     // Update the pup in the pupIndex
     if (this.pupIndex[pupId]) {
       const indexedPup = this.pupIndex[pupId];
@@ -145,7 +145,6 @@ class PkgController {
     }
 
     // Request an update to re-render the host with new data
-    console.log('Pup Now looks like', this.pupIndex[pupId]);
     this.notify(pupId);
   }
 
@@ -163,7 +162,7 @@ class PkgController {
     });
 
     if (!res || res.error) {
-      callbacks.onError({ error: true });
+      callbacks.onError({ error: true, message: 'failure occured when calling postConfig' });
       return false;
     }
 

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,5 +1,8 @@
+import { postConfig } from '/api/config/config.js';
+
 class PkgController {
   observers = [];
+  actions = [];
   pupIndex = {};
   installed = [];
   available = [];
@@ -60,24 +63,119 @@ class PkgController {
     }
   }
 
-  savePupChanges(pupId, newData) {
-    // Update the pup in the installed list
-    const installedIndex = this.installed.findIndex(pup => pup.manifest.id === pupId);
-    if (installedIndex !== -1) {
-      const installedPup = this.installed[installedIndex];
-      // Update the installed pup with new data
-      this.installed[installedIndex] = { ...installedPup, ...newData };
+  registerAction(txn, callbacks, actionType, pupId) {
+    if (!txn || !callbacks || !actionType || !pupId) {
+      console.warn(`
+        pkgController: MALFORMED REGISTER ACTION REQUEST.
+        Expecting: txn, callbacks, actionType & pupId`,
+        { txn, callbacks, actionType, pupId }
+      )
+      return;
     }
+
+    if (typeof callbacks.onSuccess !== 'function') {
+      console.warn('pkgController: ACTION SUCCESS CALLBACK NOT A FUNCTION.', { txn, callbacks })
+      return;
+    }
+
+    if (typeof callbacks.onError !== 'function') {
+      console.warn('pkgController: ACTION ERROR CALLBACK NOT A FUNCTION.', { txn, callbacks })
+      return;
+    }
+
+    this.actions.push({
+      txn,
+      callbacks,
+      actionType,
+      pupId
+    })
+  }
+
+  resolveAction(txn, payload) {
+    const foundAction = this.actions.find(action => action.txn === txn);
+    if (!foundAction) {
+      console.warn('pkgController: ACTION NOT FOUND.', { txn })
+      return;
+    }
+
+    // Txn failed, invoke error callback.
+    if (!payload || payload.error) {
+      console.warn('txn contained error', { txn, payload });
+      foundAction.callbacks.onError(payload).catch((err) => {
+        console.warn('pkgController: ERROR CALLBACK ENCOUNTERED AN ERROR', err);
+      });
+      return;
+    }
+
+    // Txn succeeded, invoke success callback.
+    console.log('Proceeding to call registered action onSuccess callback');
+    foundAction.callbacks.onSuccess(payload).catch((err) => {
+      console.warn('pkgController: SUCCESS CALLBACK ENCOUNTERED AN ERROR', err);
+    })
+
+    switch (foundAction.actionType) {
+      case 'UPDATE-PUP':
+        this.updatePupModel(foundAction.pupId, payload.update);
+        break;
+    }
+  }
+
+  updatePupModel(pupId, newPupStateData) {
+    // Update the pup in the installed list
+    // const installedIndex = this.installed.findIndex(pup => pup.manifest.id === pupId);
+    // if (installedIndex !== -1) {
+    //   const installedPup = this.installed[installedIndex];
+    //   // Update the installed pup with new data
+    //   this.installed[installedIndex] = { ...installedPup, ...newData };
+    // }
+
+    console.log('UPDATE PUP MODEL CALLED WITH', { pupId, newPupStateData });
 
     // Update the pup in the pupIndex
     if (this.pupIndex[pupId]) {
       const indexedPup = this.pupIndex[pupId];
       // Update the indexed pup with new data
-      this.pupIndex[pupId] = { ...indexedPup, ...newData };
+      this.pupIndex[pupId] = {
+        ...indexedPup,
+        state: {
+          ...indexedPup.state,
+          ...newPupStateData
+        }
+      };
     }
 
     // Request an update to re-render the host with new data
+    console.log('Pup Now looks like', this.pupIndex[pupId]);
     this.notify(pupId);
+  }
+
+  async requestPupChanges(pupId, newData, callbacks) {
+
+    if (!pupId || !newData || !callbacks) {
+      console.warn('Error. requestPupChanges expected pupId, newData, callbacks', { pupId, newData, callbacks});
+    }
+
+    const actionType = 'UPDATE-PUP';
+
+    // Make a network call
+    const res = await postConfig(pupId, newData).catch((err) => {
+      console.error(err);
+    });
+
+    if (!res || res.error) {
+      callbacks.onError({ error: true });
+      return false;
+    }
+
+    // Submitting changes succeeded, carry on.
+    const txn = res.id
+    if (txn && callbacks) {
+      // Register transaction in actions register.
+      this.registerAction(txn, callbacks, actionType, pupId)
+    }
+
+    // Return truthy to caller
+    return true;
   }
 }
 

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -1,5 +1,7 @@
 import WebSocketClient from '/api/sockets.js';
 import { store } from '/state/store.js';
+import { pkgController } from '/controllers/package/index.js';
+import { asyncTimeout } from '/utils/timeout.js';
 
 class SocketChannel {
   observers = [];
@@ -32,6 +34,24 @@ class SocketChannel {
 
     this.wsClient.onMessage = async (event) => {
       console.log('MSSSGSG!~', event);
+      const data = JSON.parse(event.data);
+
+      // Switch on message type
+      if (!data.type) {
+        console.warn('received an event that lacks an event type', event)
+        return
+      }
+
+      switch (data.type) {
+        case 'PupStatus':
+
+          // TODO: determine why.
+          // Receiving completed txns before the txn has been registered in the client.
+          await asyncTimeout(500);
+
+          pkgController.resolveAction(data.id, data);
+          break;
+      }
     };
 
     this.wsClient.onError = (event) => {

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -34,7 +34,16 @@ class SocketChannel {
 
     this.wsClient.onMessage = async (event) => {
       console.log('MSSSGSG!~', event);
-      const data = JSON.parse(event.data);
+
+      let err, data;
+      try {
+        data = JSON.parse(event.data)
+      } catch(err) {
+        console.warn('failed to JSON.parse incoming event', event);
+        err = true;
+      };
+
+      if (err || !data) return;
 
       // Switch on message type
       if (!data.type) {

--- a/src/utils/debug-panel.js
+++ b/src/utils/debug-panel.js
@@ -60,27 +60,27 @@ class DebugPanel extends LitElement {
     super();
     this.isVisible = false;
     this.logMessages = [];
-    this.originalConsoleLog = console.log;
-    this.originalConsoleInfo = console.info;
-    this.originalConsoleError = console.error;
+    // this.originalConsoleLog = console.log;
+    // this.originalConsoleInfo = console.info;
+    // this.originalConsoleError = console.error;
 
-    console.log = (...args) => {
-      this.logMessages.push({ type: 'log', args });
-      this.originalConsoleLog(...args);
-      this.requestUpdate();
-    };
+    // console.log = (...args) => {
+    //   this.logMessages.push({ type: 'log', args });
+    //   this.originalConsoleLog(...args);
+    //   this.requestUpdate();
+    // };
 
-    console.info = (...args) => {
-      this.logMessages.push({ type: 'info', args });
-      this.originalConsoleInfo(...args);
-      this.requestUpdate();
-    };
+    // console.info = (...args) => {
+    //   this.logMessages.push({ type: 'info', args });
+    //   this.originalConsoleInfo(...args);
+    //   this.requestUpdate();
+    // };
 
-    console.error = (...args) => {
-      this.logMessages.push({ type: 'error', args });
-      this.originalConsoleError(...args);
-      this.requestUpdate();
-    }
+    // console.error = (...args) => {
+    //   this.logMessages.push({ type: 'error', args });
+    //   this.originalConsoleError(...args);
+    //   this.requestUpdate();
+    // }
   }
 
   firstUpdated() {
@@ -160,9 +160,9 @@ class DebugPanel extends LitElement {
   // Disconnect custom methods when element is removed to avoid memory leaks
   disconnectedCallback() {
     super.disconnectedCallback();
-    console.log = this.originalConsoleLog;
-    console.info = this.originalConsoleInfo;
-    console.error = this.originalConsoleError;
+    // console.log = this.originalConsoleLog;
+    // console.info = this.originalConsoleInfo;
+    // console.error = this.originalConsoleError;
   }
 }
 


### PR DESCRIPTION
This PR implements the mechanisms to submit data to dogeboxd and handle its results.

Primary changes:
- Dynamic form updated to handle synchronous and asynchronous interactions with a backend (explained below)
- Test harness added and initial tests written for dynamic-form

Secondary changes:
- Error alert added for failed pup config changes
- Redundant console logs removed
- @web/dev-server version bumped from 0.4.3 to 0.4.4

## Specifics

How can dynamic form be used in a synchronous and asynchronous interaction with a server?**

> And what do I mean by sync and async here?

**Sync scenario**
1. User edits some fields
2. Clicks submit
3. Client makes a POST request to server
4. Server responds with 200 OK, signalling the save was successful <-- IMPORTANT
5. Client celebrates with confetti and the current state of the form is now the only state. 

**Meaning, there's no more "discard changes" button.  Any future changes will only revert back (if the user presses discard changes) to the saved state, nothing earlier.

**Async scenario**
1. User edits some fields
2. Clicks submit
3. Client makes a POST request to server
4. Server responds with 200 OK, signalling the changes were received <-- KEY DISTINCTION
5. Client awaits some confirmation by some other means (a web socket perhaps)
6. Client receives needed confirmation from server
7. Client can now call `dynamicForm.commitChanges()` which overrides the components initialValues with its currentValues meaning (see above**)

### How do I choose?
Dynamic Form assumes a sync scenario by default.
To flick it into the async mode (aka 'I want to commit changes manually'), tack on the `requireCommit` attribute

```
<dynamic-form
  requireCommit
</dynamic-form>
```

By default, when a user clicks submit the following occurs:
1. Validation checked, and if valid:
2. Loading state enabled
3. The provided `onSubmit()` fn is called
4. and if the above executes without complaint, `commitChanges()` is called.

`requireCommit` prevents step 4 from occurring. commitChanges() is not called after the onSubmit handlers execution.  It allows/expects you to call it at some point of your choosing