### PR TITLE
Tidy: Dynamic Form

### DIFF
--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -1,8 +1,8 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import * as methods from "/components/common/dynamic-form/index.js";
 import { bindToClass } from "/utils/class-bind.js";
 import { styles } from "./styles.js";
-import debounce from "/utils/debounce.js";
+import { onceThenDebounce } from "/utils/debounce.js";
 
 class DynamicForm extends LitElement {
   static get properties() {
@@ -88,7 +88,9 @@ class DynamicForm extends LitElement {
     if (!this.fields?.sections) return;
 
     return html`
-      <sl-resize-observer @sl-resize=${debounce(this._handleResize, 300)}>
+      <sl-resize-observer
+        @sl-resize=${onceThenDebounce(this._handleResize, 300)}
+      >
         <div class="dynamic-form-wrapper">
           ${this._generateOneOrManyForms(this.fields)}
         </div>

--- a/src/components/common/dynamic-form/lib/handlers.js
+++ b/src/components/common/dynamic-form/lib/handlers.js
@@ -1,25 +1,24 @@
-
 export function _handleResize(event) {
   const width = event.detail.entries[0].contentRect.width;
-  this._orientation = width >= 680 ? 'landscape' : 'portrait';
+  this._orientation = width >= 680 ? "landscape" : "portrait";
 }
 
 export function _handleInput(event) {
   const { currentKey } = this.propKeys(event.target.name);
   this[currentKey] = event.target.value;
-  this._checkForChanges(event.target.name, event.target.value)
+  this._checkForChanges(event.target.name, event.target.value);
 }
 
 export function _handleToggle(event) {
   const { currentKey } = this.propKeys(event.target.name);
   this[currentKey] = event.target.checked;
-  this._checkForChanges(event.target.name, event.target.checked)
+  this._checkForChanges(event.target.name, event.target.checked);
 }
 
 export function _handleChoice(event) {
   const { currentKey } = this.propKeys(event.target.name);
   this[currentKey] = event.target.value;
-  this._checkForChanges(event.target.name, event.target.value)
+  this._checkForChanges(event.target.name, event.target.value);
 }
 
 export function _handleTabChange(event, tabName) {
@@ -30,13 +29,14 @@ export function _handleDiscardChanges(event) {
   event.preventDefault();
 
   // Reset fields of active form to initial data state
-  const modifiedFieldNodes = this.shadowRoot.querySelectorAll(`#${this._activeFormId} [data-dirty-field]`)
-  Array
-    .from(modifiedFieldNodes)
-    .map(node => node.name)
+  const modifiedFieldNodes = this.shadowRoot.querySelectorAll(
+    `#${this._activeFormId} [data-dirty-field]`,
+  );
+  Array.from(modifiedFieldNodes)
+    .map((node) => node.name)
     .forEach((fieldName) => {
       const { currentKey, originalKey } = this.propKeys(fieldName);
-      this[currentKey] = this[originalKey];
+      this[currentKey] = this[originalKey] || "";
     });
 
   this._checkForChanges();

--- a/src/components/common/dynamic-form/renders/form.js
+++ b/src/components/common/dynamic-form/renders/form.js
@@ -1,89 +1,89 @@
-import { html, nothing, repeat } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+import { html, nothing, repeat } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function _generateOneOrManyForms(data) {
   const tabs = data.sections.map((section, index) => {
     const changeCount = this[`_form_${section.name}_count`];
     return html`
       <sl-tab
-        @click=${(event ) => this._handleTabChange(event, section.name)}
+        @click=${(event) => this._handleTabChange(event, section.name)}
         slot="nav"
         ?disabled=${this._loading}
         class="capitalize"
-        panel="${section.name}">
-          ${section.name}
-          ${changeCount ? html`
-            <sl-tag pill size="small" 
-              class="tag-change-indicator" 
-              variant="neutral"
-            >${changeCount}` : nothing }
-            </sl-tag>
+        panel="${section.name}"
+      >
+        ${section.name}
+        <sl-tag
+          pill
+          size="small"
+          ?data-active=${changeCount}
+          class="tag-change-indicator"
+          variant="neutral"
+          >${changeCount}
+        </sl-tag>
       </sl-tab>
-    `
+    `;
   });
 
   const form = (section, index = 0) => {
-    const formFields = repeat(section.fields, (field) => field.name, (field) => this._generateField(field))
+    const formFields = repeat(
+      section.fields,
+      (field) => field.name,
+      (field) => this._generateField(field),
+    );
     const formControls = this._generateFormControls({
       formId: section.name,
-      submitLabel: section.submitLabel || 'Save'
-    })
+      submitLabel: section.submitLabel || "Save",
+    });
     return html`
       <form
         id=${section.name}
         @submit=${this._handleSubmit}
         ?data-mark-modified=${this.markModifiedFields}
       >
-        ${formFields}
-        ${formControls}
+        ${formFields} ${formControls}
       </form>
-    `
-  }
+    `;
+  };
 
   const panels = data.sections.map((section, index) => {
     return html`
       <sl-tab-panel name=${section.name}>
         ${form(section, index)}
       </sl-tab-panel>
-    `
+    `;
   });
 
   // if mutliple sections, render tabs and panels
   if (data.sections.length > 1)
-  return html`
-    <sl-tab-group 
-      placement=${this._orientation === 'portrait' ? 'top' : 'start' }>
-      ${tabs}
-      ${panels}
-    </sl-tab-group>
-  `
+    return html`
+      <sl-tab-group
+        placement=${this._orientation === "portrait" ? "top" : "start"}
+      >
+        ${tabs} ${panels}
+      </sl-tab-group>
+    `;
 
   if (data.sections.length === 1) {
-    return html`
-      ${form(data.sections[0])}
-    `
+    return html` ${form(data.sections[0])} `;
   }
 }
 
 export function _generateField(field) {
   try {
     if (field.hidden) return nothing;
-    if (field.type === 'number') {
+    if (field.type === "number") {
       return html`
-        <div class="form-control">
-          ${this[`_render_${field.type}`](field)}
-        </div>
-      `
+        <div class="form-control">${this[`_render_${field.type}`](field)}</div>
+      `;
     } else {
       return html`
-        <div class="form-control">
-          ${this[`_render_${field.type}`](field)}
-        </div>
-      `
+        <div class="form-control">${this[`_render_${field.type}`](field)}</div>
+      `;
     }
   } catch (fieldRenderError) {
-    console.error('Dynamic form field error:', { field, fieldRenderError })
-    return this._generateErrorField(field)
-  } 
+    console.error("Dynamic form field error:", { field, fieldRenderError });
+    return this._generateErrorField(field);
+  }
 }
 
 export function _generateErrorField(field) {
@@ -93,35 +93,39 @@ export function _generateErrorField(field) {
         label="Field Error"
         help-text="${field.type} is not a valid field type"
         value=${field.type}
-        >
+      >
         <sl-icon name="exclamation-diamond" slot="prefix"></sl-icon>
       </sl-input>
     </div>
-  `
+  `;
 }
 
 export function _generateFormControls(options = {}) {
   const changeCount = this[`_form_${options.formId}_count`];
   return html`
     <div class="footer-controls">
-      ${this.allowDiscardChanges && changeCount ? html`
-        <sl-button
-          variant="text"
-          id="${options.formId}__reset_button"
-          @click=${this._handleDiscardChanges}>
-            Discard changes
-        </sl-button>
-      ` : nothing }
+      ${this.allowDiscardChanges && changeCount
+        ? html`
+            <sl-button
+              variant="text"
+              id="${options.formId}__reset_button"
+              @click=${this._handleDiscardChanges}
+            >
+              Discard changes
+            </sl-button>
+          `
+        : nothing}
 
       <sl-button
         id="${options.formId}__save_button"
-        variant=primary
+        variant="primary"
         type="submit"
         ?loading=${this._loading}
         ?disabled=${!changeCount}
-        form=${options.formId}>
-      ${options.submitLabel || 'Save' }
-    </sl-button>
+        form=${options.formId}
+      >
+        ${options.submitLabel || "Save"}
+      </sl-button>
     </div>
-  `
+  `;
 }

--- a/src/components/common/dynamic-form/styles.js
+++ b/src/components/common/dynamic-form/styles.js
@@ -1,8 +1,11 @@
-import { css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+import { css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export const styles = css`
   form {
-    padding: 0em 0em;
+    padding: 0em 0.5em;
+  }
+  form[data-mark-modified] {
+    padding: 0em 1em;
   }
 
   /* Form tabs */
@@ -16,7 +19,9 @@ export const styles = css`
   }
 
   /* Highlighting edits */
-  form[data-mark-modified] [data-dirty-field] { position: relative; }
+  form[data-mark-modified] [data-dirty-field] {
+    position: relative;
+  }
   form[data-mark-modified] [data-dirty-field]::part(form-control-label)::before,
   form[data-mark-modified] [data-dirty-field]::part(label)::before {
     content: "~";
@@ -28,6 +33,21 @@ export const styles = css`
 
   .tag-change-indicator {
     margin-left: 0.5em;
+    display: none;
+  }
+  .tag-change-indicator[data-active] {
+    display: inline-block;
+  }
+
+  @media (min-width: 680px) {
+    .tag-change-indicator {
+      display: inline-block;
+      visibility: hidden;
+    }
+    .tag-change-indicator[data-active] {
+      display: inline-block;
+      visibility: visible;
+    }
   }
 
   /* Footer buttons (submit, discard etc) */
@@ -45,8 +65,12 @@ export const styles = css`
   }
 
   /* Wider buttons on small screens */
-  sl-button { width: 100%; }
-  @media (min-width:480px) {
-    sl-button { width: auto }
+  sl-button {
+    width: 100%;
+  }
+  @media (min-width: 480px) {
+    sl-button {
+      width: auto;
+    }
   }
 `;

--- a/src/components/common/dynamic-form/tests/dynamic-form.test.js
+++ b/src/components/common/dynamic-form/tests/dynamic-form.test.js
@@ -143,14 +143,14 @@ describe("DynamicForm", () => {
     const formControls = form.querySelectorAll('.form-control');
 
     // Should be 1 form-control element
-    expect(formControls.length).to.equal(13);
+    expect(formControls.length).to.equal(14);
     
     // Expect correct shoelace component usage
     const tags = [...formControls].map(c => c.children[0].tagName);
     expect(tags).to.deep.equal([
       'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT',
       'SL-CHECKBOX', 'SL-SWITCH', 'SL-SELECT', 'SL-RADIO-GROUP', 'SL-RADIO-GROUP', 
-      'SL-TEXTAREA', 'SL-COLOR-PICKER', 'SL-RATING']);
+      'SL-TEXTAREA', 'SL-COLOR-PICKER', 'SL-RANGE', 'SL-RATING']);
 
     // Expect correct type attribute set for the SL-INPUT (because it can be one of many)
     const textInputs = [...formControls]

--- a/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
+++ b/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
@@ -36,7 +36,7 @@ export const ONE_OF_EACH_FIELD_TYPE = [
   // Color
   { name: 'bannerColour', label: 'Banner Colour', type: 'color' },
   // Range
-  // { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
+  { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
   // Rating
   { name: 'score', label: 'Score (out of 5)', type: 'rating' },
 ]

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -9,3 +9,16 @@ export default function debounce(func, wait) {
     timeout = setTimeout(later, wait);
   };
 }
+
+export function onceThenDebounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      timeout = null;
+    };
+    const shouldCallNow = !timeout;
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+    if (shouldCallNow) func.apply(this, args);
+  };
+}


### PR DESCRIPTION
Small adjustments

1. Replace use of debounce with [onceThenDebounce](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-ac5d92e4de741493aa2a8e5661ae44c8d132a8e094c7896e5674f4666857d928R92), to remove flash of layout shifting

2. When discarding changes, if an original value does not exist, [replace current value with empty string](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-8ed41a92ed9ad67c6ffb908667db1eeb54e7314449bff1a0c2136593cd6bb0faR39).  This prevents the input box having a value of "undefined"

3. When on [wider displays](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-27a2d4da4a3b877938f501886667e3137b1a6bb6bda7d17749a67f4b62e883afR42) (and the tabs are positioned on the left), reduce layout shift by [toggling the visibility of the change counters](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-893ff0627edd45f4380bdfdd33fae725bf53dfca2159f2442fe1668d6a9121c7R18) rather than their display.

4. Apply a small 0.5em [padding to the form by default](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-27a2d4da4a3b877938f501886667e3137b1a6bb6bda7d17749a67f4b62e883afR5) (otherwise toggles and checkboxes get clipped).  Apply a 1em padding to the form when field modification marking is enabled.

5. Ensure the range field [type is tested](https://github.com/dogeorg/dpanel/compare/tidy?expand=1#diff-83134a44c3c9e5cf186d8073b29c41c6d46a4906b8055921da90c4407a53d3dbR39).  