### PR TITLE
Dynamic form tests: Conditional fields (revealOn rules)

### DIFF
--- a/src/components/common/dynamic-form/lib/diff.js
+++ b/src/components/common/dynamic-form/lib/diff.js
@@ -2,7 +2,6 @@ export function _checkForChanges() {
   if (!this.fields?.sections) return;
 
   let dirty = 0;
-  let flattenedFields = [];
 
   // Firstly, test whether any rule targeted fields have condition changes.
   this._rules.forEach((rule) => {
@@ -11,6 +10,7 @@ export function _checkForChanges() {
 
   // Secondly, check if any field differs from prior state.
   this.fields.sections.forEach((section) => {
+    let flattenedFields = [];
     let sectionChangeCount = 0;
 
     section.fields.forEach((field) => {

--- a/src/components/common/dynamic-form/tests/dynamic-form.test.js
+++ b/src/components/common/dynamic-form/tests/dynamic-form.test.js
@@ -114,10 +114,10 @@ describe("DynamicForm", () => {
     // Input should have the correct type, name and label.
     expect(formInput.getAttribute('type')).to.equal('text');
     expect(formInput.getAttribute('name')).to.equal('first');
-    expect(formInput.getAttribute('label')).to.equal('First');
+    expect(formInput.textContent).to.contain('First');
   });
 
-  it('given a multiple fields (1 of each type), should render all (14) fields with the correct input control', async () => {
+  it('given a multiple fields (1 of each type), should render all (15) fields with the correct input control', async () => {
 
     const fields = {
       sections: [
@@ -142,15 +142,15 @@ describe("DynamicForm", () => {
     const form = el.shadowRoot.querySelector('form')
     const formControls = form.querySelectorAll('.form-control');
 
-    // Should be 1 form-control element
-    expect(formControls.length).to.equal(14);
+    // Should be 15 form-control element
+    expect(formControls.length).to.equal(15);
     
     // Expect correct shoelace component usage
     const tags = [...formControls].map(c => c.children[0].tagName);
     expect(tags).to.deep.equal([
       'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT', 'SL-INPUT',
       'SL-CHECKBOX', 'SL-SWITCH', 'SL-SELECT', 'SL-RADIO-GROUP', 'SL-RADIO-GROUP', 
-      'SL-TEXTAREA', 'SL-COLOR-PICKER', 'SL-RANGE', 'SL-RATING']);
+      'SL-TEXTAREA', 'SL-COLOR-PICKER', 'SL-RANGE', 'SL-RATING', 'SL-TEXTAREA']);
 
     // Expect correct type attribute set for the SL-INPUT (because it can be one of many)
     const textInputs = [...formControls]

--- a/src/components/common/dynamic-form/tests/fields.conditional.test.js
+++ b/src/components/common/dynamic-form/tests/fields.conditional.test.js
@@ -1,0 +1,117 @@
+// Test helpers
+import { html, fixture, expect, waitUntil, elementUpdated, aTimeout } from "../../../../../dev/node_modules/@open-wc/testing";
+import { sendKeys } from '../../../../../dev/node_modules/@web/test-runner-commands';
+import { repeatKeys } from '../../../../../dev/utils/keyboard.js';
+
+// Fixtures
+import { CONDITIONAL_FIELD } from "./fixtures/conditional_field.js";
+
+// Component being tested.
+import "../dynamic-form.js";
+
+describe("DynamicForm", () => {
+
+  it('when a conditional fields ruling is not met, it is not displayed', async () => {
+    const fields = CONDITIONAL_FIELD;
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+    const formControls = form.querySelectorAll('.form-control');
+
+    // Should be 2 form-control element
+    expect(formControls.length).to.equal(2);
+
+    // Expecting an inital two fields, an input and a select.
+    const tags = [...formControls].map(c => c.children[0].tagName);
+    expect(tags).to.deep.equal(['SL-INPUT', 'SL-SELECT']);
+  });
+
+  it('when a conditional fields ruling is already met, it is displayed', async () => {
+    const fields = CONDITIONAL_FIELD;
+    
+    // The form reveals 2 more fields when network has a value of 'hidden'
+    const values = {
+      network: 'hidden'
+    }
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+        .values=${values}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+    const formControls = form.querySelectorAll('.form-control');
+
+    // Should be 2 form-control element
+    expect(formControls.length).to.equal(4);
+
+    // Expecting an inital four fields (because all conditions are met)
+    const tags = [...formControls].map(c => c.children[0].tagName);
+    expect(tags).to.deep.equal(['SL-INPUT', 'SL-SELECT', 'SL-INPUT', 'SL-INPUT']);
+  });
+
+  it('when a conditional fields ruling becomes met, it is displayed', async () => {
+    const fields = CONDITIONAL_FIELD;
+
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.values, 'Values did not become ready');
+
+    // Target form
+    const form = el.shadowRoot.querySelector('form')
+    const formControls = form.querySelectorAll('.form-control');
+
+    // Should be 1 form-control element
+    expect(formControls.length).to.equal(2);
+
+    // Expecting an inital two fields, an input and a select.
+    const tags = [...formControls].map(c => c.children[0].tagName);
+    expect(tags).to.deep.equal(['SL-INPUT', 'SL-SELECT']);
+
+    // Now meet the rule condition:
+    // Set focus on field, using dynamic-form custom focus() method
+    el.focus('network');
+
+    // With the sl-input now in focus, select the second option of the dropdown
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+    expect(el._network).to.equal('hidden')
+
+    await elementUpdated(el);
+
+    // Recount the number of fields.
+    const formAgain = el.shadowRoot.querySelector('form')
+    const formControlsAgain = formAgain.querySelectorAll('.form-control');
+    expect(formControlsAgain.length).to.equal(4);
+
+    // Now Expecting the initial two fields PLUS a revealed third and forth input field.
+    const tagsAgain = [...formControlsAgain].map(c => c.children[0].tagName);
+    expect(tagsAgain).to.deep.equal(['SL-INPUT', 'SL-SELECT', 'SL-INPUT', 'SL-INPUT']);
+  });
+
+});
+

--- a/src/components/common/dynamic-form/tests/fixtures/conditional_field.js
+++ b/src/components/common/dynamic-form/tests/fixtures/conditional_field.js
@@ -1,0 +1,44 @@
+export const CONDITIONAL_FIELD = {
+  sections: [
+    {
+      name: "Select Network",
+      submitLabel: "Much Connect",
+      fields: [
+        {
+          name: "device",
+          label: "Set device name",
+          labelAction: { name: "generate-name", label: "Randomize" },
+          type: "text",
+          required: true,
+          breakline: true,
+        },
+        {
+          name: "network",
+          label: "Select Network",
+          labelAction: { name: "refresh", label: "Refresh" },
+          type: "select",
+          required: true,
+          options: [
+            { type: "ethernet", value: "ethernet", label: "Ethernet" },
+            { type: "wifi", value: "hidden", label: "Hidden Network" },
+          ],
+        },
+        {
+          name: "network-ssid",
+          label: "Network SSID",
+          type: "text",
+          required: true,
+          revealOn: ["network", "=", "hidden"],
+        },
+        {
+          name: "network-pass",
+          label: "Network Password",
+          type: "password",
+          required: true,
+          passwordToggle: true,
+          revealOn: ["network", "!=", "ethernet"],
+        },
+      ],
+    },
+  ],
+};

--- a/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
+++ b/src/components/common/dynamic-form/tests/fixtures/one_of_each_field_type.js
@@ -39,4 +39,6 @@ export const ONE_OF_EACH_FIELD_TYPE = [
   { name: 'handicap', label: 'Handicap (0 - 100)', type: 'range' },
   // Rating
   { name: 'score', label: 'Score (out of 5)', type: 'rating' },
+  // Seedphrase
+  { name: 'twelve-words', label: 'Recovery Phrase', type: 'seedphrase' },
 ]

--- a/src/components/views/library-view/renders/section_installed.js
+++ b/src/components/views/library-view/renders/section_installed.js
@@ -65,6 +65,9 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
             version=${pkg.manifest.version}
             icon="box"
             installed
+            .config=${pkg.manifest.command.config}
+            .options=${pkg.state.config}
+            status=${pkg.state.status}
             .docs=${pkg.manifest.docs}
             .gui=${pkg.manifest.gui}
             @click=${this.handlePupClick}

--- a/src/components/views/pup-snapshot/pup-snapshot.js
+++ b/src/components/views/pup-snapshot/pup-snapshot.js
@@ -56,6 +56,7 @@ class PupSnapshot extends LitElement {
     this.options = {};
     this.config = {};
     this.router = getRouter().Router;
+    this.allowInspect = true;
     // Bind all imported renderMehtods to 'this'
     bindToClass(renderMethods, this)
   }


### PR DESCRIPTION
This PR adds a couple of tests asserting whether fields with revealOn rules appear when the conditions are met.

Unrelated improvements:
- Pup component "Configure" action was revealing the correct tab, but not expanding the pup accordion.
- Fixes an correct dirty field count that occurred due to an ill scoped variable in diff.js