### PR TITLE
Dynamic form: add getState and getFormValues methods

### DIFF
--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -43,6 +43,7 @@ class DynamicForm extends LitElement {
     this._orientation = "portrait";
     this.theme = ''
     this._rules = [];
+    this._flattenedFields = [];
   }
 
   set fields(newValue) {
@@ -109,6 +110,32 @@ class DynamicForm extends LitElement {
     const { labelKey } = this.propKeys(fieldName);
     this[labelKey] = !this[labelKey];
     this.requestUpdate();
+  }
+
+  getFormValues() {
+    // Purpose of this method is to return the values of the form
+    // In a key/val structure, where key is the field name, val is the field value.
+    // eg. { colour: '#0000FF' }
+    const form = this.shadowRoot.querySelector(`#${this._activeFormId}`);
+    return this.getChanges(form);
+  }
+
+  getState() {
+    // Extending getFormValues, this does the same except for any field that has
+    // an options property, it will supply the selected option object as the value.
+    // eg. { colour: { value: '#0000FF', label: 'Blue', primary: true } }
+    const form = this.shadowRoot.querySelector(`#${this._activeFormId}`);
+    let state = this.getChanges(form);
+    let out = {}
+
+    Object.keys(state).forEach(key => {
+      const field = this._flattenedFields.find(field => field.name === key);
+      out[key] = field.options
+        ? field.options.find(option => option.value === state[key])
+        : state[key];
+    });
+
+    return out;
   }
 
   setValue(fieldName, newValue) {

--- a/src/components/common/dynamic-form/lib/props.js
+++ b/src/components/common/dynamic-form/lib/props.js
@@ -6,20 +6,20 @@ export function _initializeFormFieldProperties(newValue) {
     });
     this[`_form_${section.name}_count`] = 0;
 
-    let flattenedFields = [];
+    this._flattenedFields = [];
     section.fields.forEach((field) => {
       // Push all field types.
-      flattenedFields.push(field);
+      this._flattenedFields.push(field);
 
       // Additionally, for toggleFields push nested fields.
       if (field.type === "toggleField") {
         field.fields.forEach((f) => {
-          flattenedFields.push(f);
+          this._flattenedFields.push(f);
         });
       }
     });
 
-    flattenedFields.forEach((field) => {
+    this._flattenedFields.forEach((field) => {
       const {
         currentKey,
         originalKey,

--- a/src/components/common/dynamic-form/tests/field.select.test.js
+++ b/src/components/common/dynamic-form/tests/field.select.test.js
@@ -1,0 +1,201 @@
+// Test helpers
+import { html, fixture, expect, waitUntil, elementUpdated, aTimeout } from "../../../../../dev/node_modules/@open-wc/testing";
+import { sendKeys } from '../../../../../dev/node_modules/@web/test-runner-commands';
+import { repeatKeys } from '../../../../../dev/utils/keyboard.js';
+
+// Component being tested.
+import "../dynamic-form.js";
+
+const selectWithStandardOptions = { 
+  name: 'colour',
+  label: 'Favourite Colour',
+  type: 'select',
+  options: [
+    { name: '#FF0000', label: 'Red' },
+    { name: '#0000FF', label: 'Blue' },
+    { name: '#00FF00', label: 'Green' },
+  ]
+}
+
+describe("A select field, with options", async () => {
+
+  const fields = {
+    sections: [
+      { 
+        name: 'section-foo', 
+        fields: [{ 
+          name: 'colour',
+          label: 'Favourite Colour',
+          type: 'select',
+          options: [
+            { value: '#FF0000', label: 'Red' },
+            { value: '#0000FF', label: 'Blue' },
+            { value: '#00FF00', label: 'Green' },
+          ]
+        }]
+      }
+    ]
+  }
+
+  it('renders all options with accurate label', async () => {
+  
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const options = el.shadowRoot.querySelectorAll('sl-option')
+
+    expect(options.length).to.equal(3);
+    expect(options[0].textContent).to.equal("Red")
+    expect(options[1].textContent).to.equal("Blue")
+    expect(options[2].textContent).to.equal("Green")
+  
+  });
+
+  it("on submit, the selected option's value is accurate", async () => {
+
+    const values = {
+      colour: '#FF0000'
+    }
+  
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+        .values=${values}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const options = el.shadowRoot.querySelectorAll('sl-option');
+
+    el.focus('colour');
+
+    // With the sl-input now in focus, select the second option of the dropdown
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+
+    expect(el._colour).to.equal('#0000FF');
+  
+  });
+
+});
+
+describe("Methods: getState, getFormValues", async () => {
+
+  const fields = {
+    sections: [
+      { 
+        name: 'section-foo', 
+        fields: [
+        {
+          name: 'flavour',
+          label: 'Flavour',
+          type: 'text',
+        },
+        { 
+          name: 'colour',
+          label: 'Favourite Colour',
+          type: 'select',
+          options: [
+            { value: '#FF0000', label: 'Red', primary: true  },
+            { value: '#0000FF', label: 'Blue', primary: true },
+            { value: '#00FF00', label: 'Green', primary: false },
+            { value: '#FFFF00', label: 'Yellow', primary: true },
+          ]
+        }]
+      }
+    ]
+  }
+
+    it('getFormValues returns siple key/val pairs', async () => {
+  
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const options = el.shadowRoot.querySelectorAll('sl-option');
+
+    el.focus('colour');
+
+    // With the sl-input now in focus, select the second option of the dropdown
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+
+    await waitUntil(() => el._colour, 'color did not update');
+
+    el.focus('flavour');
+    await sendKeys({ type: 'chocolate' });
+
+    await waitUntil(() => el._flavour, 'flavour did not update');
+
+    const expectedValues = { 
+      "colour": "#0000FF",
+      "flavour": "chocolate",
+    }
+
+    expect(el.getFormValues()).to.deep.equal(expectedValues);
+
+  });
+
+  it('getState returns key/val pairs WITH selected objects', async () => {
+  
+    // Initialise the component
+    const el = await fixture(html`
+      <dynamic-form
+        .fields=${fields}
+      ></dynamic-form>
+    `);
+
+    // Wait until fields are initialized
+    await waitUntil(() => el.fields, 'Fields did not become ready');
+
+    // Target form
+    const options = el.shadowRoot.querySelectorAll('sl-option');
+
+    el.focus('colour');
+
+    // With the sl-input now in focus, select the second option of the dropdown
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'ArrowDown' });
+    await sendKeys({ press: 'Enter' });
+
+    await waitUntil(() => el._colour, 'color did not update');
+
+    el.focus('flavour');
+    await sendKeys({ type: 'chocolate' });
+
+    await waitUntil(() => el._flavour, 'flavour did not update');
+
+    const expectedState = { 
+      "colour": {
+        "label": "Blue",
+        "primary": true,
+        "value": "#0000FF",
+      },
+      "flavour" : "chocolate",
+    }
+
+    expect(el.getState()).to.deep.equal(expectedState);
+
+  });
+});

--- a/src/components/common/dynamic-form/tests/field.select.test.js
+++ b/src/components/common/dynamic-form/tests/field.select.test.js
@@ -6,17 +6,6 @@ import { repeatKeys } from '../../../../../dev/utils/keyboard.js';
 // Component being tested.
 import "../dynamic-form.js";
 
-const selectWithStandardOptions = { 
-  name: 'colour',
-  label: 'Favourite Colour',
-  type: 'select',
-  options: [
-    { name: '#FF0000', label: 'Red' },
-    { name: '#0000FF', label: 'Blue' },
-    { name: '#00FF00', label: 'Green' },
-  ]
-}
-
 describe("A select field, with options", async () => {
 
   const fields = {
@@ -59,7 +48,7 @@ describe("A select field, with options", async () => {
   
   });
 
-  it("on submit, the selected option's value is accurate", async () => {
+  it("on change, the selected option's value is accurate", async () => {
 
     const values = {
       colour: '#FF0000'


### PR DESCRIPTION
`getFormValues()` can be called to obtain a simple key/val pair structure of the forms current state.

eg:
```
{ 
  "flavour": "chocolate"
  "colour": "#0000FF",
}
```

`getState()` can be called to obtain an enriched structure of the form's data, where, any field with options will now have its value set as the selected option.

```
{ 
  "flavour" : "chocolate",
  "colour": {
    "label": "Blue",
    "primary": true,
    "value": "#0000FF",
  }
}
```