### PR TITLE
Dynamic Form: RevealOn as Function

### DIFF
--- a/src/api/network/get-networks.mocks.js
+++ b/src/api/network/get-networks.mocks.js
@@ -5,8 +5,8 @@ export const getResponse = {
   res: {
     success: true,
     networks: [
-      { type: "ethernet", value: "ethernet", label: "Ethernet", encryption: "MAXIMUM" },
-      { type: "wifi", value: "home-wifi", label: "Home Wifi", encryption: "PSK" },
+      { type: "ethernet", value: "ethernet", label: "Ethernet" },
+      { type: "wifi", value: "home-wifi", label: "Home Wifi", encryption: "PSK", selected: true },
     ],
   }
 }

--- a/src/api/network/get-networks.mocks.js
+++ b/src/api/network/get-networks.mocks.js
@@ -5,8 +5,8 @@ export const getResponse = {
   res: {
     success: true,
     networks: [
-      { type: "ethernet", value: "ethernet", label: "Ethernet" },
-      { type: "wifi", value: "home-wifi", label: "Home Wifi" },
+      { type: "ethernet", value: "ethernet", label: "Ethernet", encryption: "MAXIMUM" },
+      { type: "wifi", value: "home-wifi", label: "Home Wifi", encryption: "PSK" },
     ],
   }
 }

--- a/src/api/setup/get-bootstrap.mocks.js
+++ b/src/api/setup/get-bootstrap.mocks.js
@@ -5,8 +5,8 @@ export const getResponse = {
   res: {
     success: true,
     setup: {
-      hasPassword: false,
-      hasKey: false,
+      hasPassword: true,
+      hasKey: true,
       hasConnection: false,
     },
   }

--- a/src/api/setup/get-bootstrap.mocks.js
+++ b/src/api/setup/get-bootstrap.mocks.js
@@ -5,8 +5,8 @@ export const getResponse = {
   res: {
     success: true,
     setup: {
-      hasPassword: true,
-      hasKey: true,
+      hasPassword: false,
+      hasKey: false,
       hasConnection: false,
     },
   }

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -116,34 +116,21 @@ class DynamicForm extends LitElement {
     // Purpose of this method is to return the values of the form
     // In a key/val structure, where key is the field name, val is the field value.
     // eg. { colour: '#0000FF' }
-    const form = this.shadowRoot.querySelector(`#${this._activeFormId}`);
-    return this.getChanges(form);
+    let out = {}
+    this._flattenedFields.forEach(field => {
+      out[field.name] = this[`_${field.name}`]
+    });
   }
 
   getState = () => {
     // Extending getFormValues, this does the same except for any field that has
     // an options property, it will supply the selected option object as the value.
     // eg. { colour: { value: '#0000FF', label: 'Blue', primary: true } }
-    const form = this.shadowRoot.querySelector(`#${this._activeFormId}`);
-
-    // let state = this.getChanges(form);
-    // let out = {}
-
-    // Object.keys(state).forEach(key => {
-    //   const field = this._flattenedFields.find(field => field.name === key);
-    //   out[key] = field.options
-    //     ? field.options.find(option => option.value === state[key])
-    //     : state[key];
-    // });
-    // 
-    // return out;
-
     let out = {};
-    let state = this.getChanges(form);
     this._flattenedFields.forEach(field => {
       out[field.name] = field.options
-        ? field.options.find(option => option.value === state[field.name])
-        : state[field.name]
+        ? field.options.find(option => option.value === this[`_${field.name}`])
+        : this[`_${field.name}`]
     });
 
     return out;

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -120,6 +120,7 @@ class DynamicForm extends LitElement {
     this._flattenedFields.forEach(field => {
       out[field.name] = this[`_${field.name}`]
     });
+    return out;
   }
 
   getState = () => {

--- a/src/components/common/dynamic-form/dynamic-form.js
+++ b/src/components/common/dynamic-form/dynamic-form.js
@@ -112,7 +112,7 @@ class DynamicForm extends LitElement {
     this.requestUpdate();
   }
 
-  getFormValues() {
+  getFormValues = () => {
     // Purpose of this method is to return the values of the form
     // In a key/val structure, where key is the field name, val is the field value.
     // eg. { colour: '#0000FF' }
@@ -120,19 +120,30 @@ class DynamicForm extends LitElement {
     return this.getChanges(form);
   }
 
-  getState() {
+  getState = () => {
     // Extending getFormValues, this does the same except for any field that has
     // an options property, it will supply the selected option object as the value.
     // eg. { colour: { value: '#0000FF', label: 'Blue', primary: true } }
     const form = this.shadowRoot.querySelector(`#${this._activeFormId}`);
-    let state = this.getChanges(form);
-    let out = {}
 
-    Object.keys(state).forEach(key => {
-      const field = this._flattenedFields.find(field => field.name === key);
-      out[key] = field.options
-        ? field.options.find(option => option.value === state[key])
-        : state[key];
+    // let state = this.getChanges(form);
+    // let out = {}
+
+    // Object.keys(state).forEach(key => {
+    //   const field = this._flattenedFields.find(field => field.name === key);
+    //   out[key] = field.options
+    //     ? field.options.find(option => option.value === state[key])
+    //     : state[key];
+    // });
+    // 
+    // return out;
+
+    let out = {};
+    let state = this.getChanges(form);
+    this._flattenedFields.forEach(field => {
+      out[field.name] = field.options
+        ? field.options.find(option => option.value === state[field.name])
+        : state[field.name]
     });
 
     return out;
@@ -145,7 +156,8 @@ class DynamicForm extends LitElement {
   }
 
   firstUpdated() {
-    this._checkForChanges()
+    this._activeFormId = this.shadowRoot.querySelector('form').id;
+    this._checkForChanges();
   }
 
   render() {

--- a/src/components/common/dynamic-form/lib/diff.js
+++ b/src/components/common/dynamic-form/lib/diff.js
@@ -43,6 +43,7 @@ export function _checkAndSetConditionMetFlags(rule, currentState, currentValues)
   const revealKey = this.propKeys(rule.self).revealKey;
 
   if (!rule.fn) {
+
     // Obtain targets current value
     const targetValue = this[this.propKeys(rule.target).currentKey]
     const desiredValue = rule.value;

--- a/src/components/common/dynamic-form/lib/on-update.js
+++ b/src/components/common/dynamic-form/lib/on-update.js
@@ -1,10 +1,17 @@
 import { customElementsReady } from '/utils/custom-elements-ready.js';
 
 export async function _onUpdate(changedProperties) {
+  if (changedProperties.has("fields") || changedProperties.has("values")) {
+    // Run rules.
+    this._checkForChanges();
+  }
+
   if (!this._shouldUpdateForm(changedProperties)) {
     return;
   }
   // Determine the appropriate form to target
+
+
   const form = this._getTargetForm(changedProperties);
   if (!form) {
     return;

--- a/src/components/common/dynamic-form/lib/props.js
+++ b/src/components/common/dynamic-form/lib/props.js
@@ -58,12 +58,22 @@ export function _initializeFormFieldProperties(newValue) {
         this.constructor.createProperty(labelKey, { type: Boolean });
 
         try {
-          const rule = {
-            self: field.name,
-            target: field.revealOn[0],
-            operator: field.revealOn[1],
-            value: field.revealOn[2],
+          let rule = {}
+
+          if (typeof field.revealOn === 'function') {
+            rule = {
+               self: field.name,
+               fn: field.revealOn
+            }
+          } else {
+            rule = {
+              self: field.name,
+              target: field.revealOn[0],
+              operator: field.revealOn[1],
+              value: field.revealOn[2],
+            }
           }
+
           this._rules.push(rule)
         } catch (ruleErr) {
           console.warn('Error with field rule', ruleErr, field.revealOn)

--- a/src/components/common/dynamic-form/tests/field.select.test.js
+++ b/src/components/common/dynamic-form/tests/field.select.test.js
@@ -108,7 +108,7 @@ describe("Methods: getState, getFormValues", async () => {
     ]
   }
 
-    it('getFormValues returns siple key/val pairs', async () => {
+    it('getFormValues returns simple key/val pairs', async () => {
   
     // Initialise the component
     const el = await fixture(html`
@@ -133,13 +133,13 @@ describe("Methods: getState, getFormValues", async () => {
     await waitUntil(() => el._colour, 'color did not update');
 
     el.focus('flavour');
-    await sendKeys({ type: 'chocolate' });
+    await sendKeys({ type: 'A' });
 
-    await waitUntil(() => el._flavour, 'flavour did not update');
+    await waitUntil(() => el._flavour === "A", 'flavour did not update');
 
     const expectedValues = { 
       "colour": "#0000FF",
-      "flavour": "chocolate",
+      "flavour": "A",
     }
 
     expect(el.getFormValues()).to.deep.equal(expectedValues);
@@ -171,9 +171,9 @@ describe("Methods: getState, getFormValues", async () => {
     await waitUntil(() => el._colour, 'color did not update');
 
     el.focus('flavour');
-    await sendKeys({ type: 'chocolate' });
+    await sendKeys({ type: 'A' });
 
-    await waitUntil(() => el._flavour, 'flavour did not update');
+    await waitUntil(() => el._flavour === "A", 'flavour did not update');
 
     const expectedState = { 
       "colour": {
@@ -181,7 +181,7 @@ describe("Methods: getState, getFormValues", async () => {
         "primary": true,
         "value": "#0000FF",
       },
-      "flavour" : "chocolate",
+      "flavour" : "A",
     }
 
     expect(el.getState()).to.deep.equal(expectedState);

--- a/src/components/common/dynamic-form/tests/fields.conditional.test.js
+++ b/src/components/common/dynamic-form/tests/fields.conditional.test.js
@@ -54,6 +54,7 @@ describe("DynamicForm", () => {
 
     // Wait until fields are initialized
     await waitUntil(() => el.values, 'Values did not become ready');
+    await aTimeout(100);
 
     // Target form
     const form = el.shadowRoot.querySelector('form')

--- a/src/components/common/dynamic-form/tests/fields.conditional.test.js
+++ b/src/components/common/dynamic-form/tests/fields.conditional.test.js
@@ -36,7 +36,7 @@ describe("DynamicForm", () => {
     expect(tags).to.deep.equal(['SL-INPUT', 'SL-SELECT']);
   });
 
-  it('when a conditional fields ruling is already met, it is displayed', async () => {
+  it.only('when a conditional fields ruling is already met, it is displayed', async () => {
     const fields = CONDITIONAL_FIELD;
     
     // The form reveals 2 more fields when network has a value of 'hidden'
@@ -59,7 +59,7 @@ describe("DynamicForm", () => {
     const form = el.shadowRoot.querySelector('form')
     const formControls = form.querySelectorAll('.form-control');
 
-    // Should be 2 form-control element
+    // Should be 4 form-control element
     expect(formControls.length).to.equal(4);
 
     // Expecting an inital four fields (because all conditions are met)

--- a/src/components/common/dynamic-form/tests/fixtures/conditional_field.js
+++ b/src/components/common/dynamic-form/tests/fixtures/conditional_field.js
@@ -1,7 +1,7 @@
 export const CONDITIONAL_FIELD = {
   sections: [
     {
-      name: "Select Network",
+      name: "select-network",
       submitLabel: "Much Connect",
       fields: [
         {

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -49,9 +49,7 @@ class SelectNetwork extends LitElement {
     this._server_fault = false;
     this._invalid_creds = false;
     this._setNetworkFields = {};
-    // this._setNetworkValues = { 'device-name': 'potato', network: 'hidden', 'network-ssid': 'BarryWifi', 'network-pass': 'Peanut' };
-    // this._setNetworkValues = { network: "ethernet" };
-    this._setNetworkFields = {}
+    this._setNetworkValues = { 'device-name': 'potato' };
     this._form = null;
   }
 
@@ -95,7 +93,8 @@ class SelectNetwork extends LitElement {
               label: "Network SSID",
               type: "text",
               required: true,
-              revealOn: ["network", "=", "hidden"],
+              // revealOn: ["network", "=", "hidden"],
+              revealOn: (state, values) => state.network && state.network.value == "hidden"
             },
             {
               name: "network-pass",
@@ -104,10 +103,10 @@ class SelectNetwork extends LitElement {
               required: true,
               passwordToggle: true,
               // revealOn: ["network", "!=", "ethernet"],
-              revealOn: (state, values) => {
-                console.log(state.network);
-                return !!(state.network && state.network.type !== "ethernet")
-              }
+              revealOn: (state, values) => Boolean(
+                (state.network && state.network.encryption === "PSK") ||
+                (state.network && state.network.type !== "ethernet")
+              )
             },
           ],
         },
@@ -131,10 +130,23 @@ class SelectNetwork extends LitElement {
 
     const { networks } = response;
 
+    // Set the retreived networks as the network field's dropdown options
+    // Set a hardcoded option of "Hidden"
     this._setNetworkFields.sections[0].fields[1].options = [
       ...networks,
       { type: "wifi", value: "hidden", label: "Hidden Network" },
     ];
+
+    // If the retrieved networks has an identifed selected network,
+    // Set it as the chosen option.
+    const selectedNetwork = networks.find((net) => net.selected);
+    if (selectedNetwork) {
+      this._setNetworkValues = {
+        ...this._setNetworkValues,
+        network: selectedNetwork.value
+      }
+    }
+
     // Stop label spinner
     this._form.toggleLabelLoader("network");
   }

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -49,7 +49,7 @@ class SelectNetwork extends LitElement {
     this._server_fault = false;
     this._invalid_creds = false;
     this._setNetworkFields = {};
-    this._setNetworkValues = { 'device-name': 'potato' };
+    this._setNetworkValues = {};
     this._form = null;
   }
 
@@ -188,6 +188,13 @@ class SelectNetwork extends LitElement {
   }
 
   _attemptSetNetwork = async (data, form, dynamicFormInstance) => {
+
+    console.log({
+      changesOnly: data,
+      currentState: dynamicFormInstance.getState(),
+      currentValues: dynamicFormInstance.getFormValues()
+    });
+
     const response = await postNetwork(data).catch(this.handleFault);
 
     if (!response) {

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -50,7 +50,8 @@ class SelectNetwork extends LitElement {
     this._invalid_creds = false;
     this._setNetworkFields = {};
     // this._setNetworkValues = { 'device-name': 'potato', network: 'hidden', 'network-ssid': 'BarryWifi', 'network-pass': 'Peanut' };
-    this._setNetworkValues = { network: "ethernet" };
+    // this._setNetworkValues = { network: "ethernet" };
+    this._setNetworkFields = {}
     this._form = null;
   }
 
@@ -66,7 +67,7 @@ class SelectNetwork extends LitElement {
     this._setNetworkFields = {
       sections: [
         {
-          name: "Select Network",
+          name: "select-network",
           submitLabel: "Much Connect",
           fields: [
             {
@@ -102,7 +103,11 @@ class SelectNetwork extends LitElement {
               type: "password",
               required: true,
               passwordToggle: true,
-              revealOn: ["network", "!=", "ethernet"],
+              // revealOn: ["network", "!=", "ethernet"],
+              revealOn: (state, values) => {
+                console.log(state.network);
+                return !!(state.network && state.network.type !== "ethernet")
+              }
             },
           ],
         },

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -183,8 +183,8 @@ class SelectNetwork extends LitElement {
   }
 
   _generateName() {
-    const rando = Math.round(Math.random() * 100);
-    this._form.setValue("device-name", `Potato_${rando}`);
+    const rando = Math.round(Math.random() * 1000);
+    this._form.setValue("device-name", `my_dogebox_${rando}`);
   }
 
   _attemptSetNetwork = async (data, form, dynamicFormInstance) => {


### PR DESCRIPTION
This PR allows form authors to supply a function as a `revealOn` rule.

Changes:
- getState and getFormValues were only returning CHANGED values, now provides ALL 
- When form field definitions change (ie, if a select's set of options change), we ensure that rules are re-processed.

![network-reveal-on](https://github.com/user-attachments/assets/b8994e70-3edd-43a1-9e08-7717986b83dc)
