### PR TITLE
Pup page - config submit handler

### DIFF
--- a/src/api/config/config.mocks.js
+++ b/src/api/config/config.mocks.js
@@ -5,6 +5,7 @@ export const postResponse = {
   res: {
     success: true,
     message: "Winner winner, chicken dinner",
+    id: 123
   }
 }
 

--- a/src/api/sockets.js
+++ b/src/api/sockets.js
@@ -1,7 +1,7 @@
 export default class WebSocketClient {
-  constructor(url, useMocks, mockEventGenerator) {
+  constructor(url, networkContext, mockEventGenerator) {
     this.url = url;
-    this.useMocks = useMocks;
+    this.useMocks = networkContext?.useMocks;
     this.mockEventGenerator = mockEventGenerator;
     this.stopMocking = () => console.log('Stop function not provided.');
     this.socket = null;

--- a/src/components/common/alert.js
+++ b/src/components/common/alert.js
@@ -21,19 +21,24 @@ export function createAlert(variant, message, icon = 'info-circle', duration = 0
     : escapeHtml(message)
 
   const actionEl = action ? `
-    <a class="more" href="#error-details">${action.text}</sl-button>
+    <a class="more" no-intercept href="${`${window.location.href}?error=true`}">${action.text}</sl-button>
     ` : nothing
 
   alert.innerHTML = `
     ${iconEl}
     ${messageEl}
+    ${actionEl}
   `
 
   document.body.append(alert);
 
   if (action) {
-    const anchor = alert.querySelector("a.more")
-    anchor.addEventListener("click", () => createMoreDetailDialog(messageEl, errorDetail))
+    try {
+      const anchor = alert.querySelector("a.more")
+      anchor.addEventListener("click", (e) => { e.preventDefault(); createMoreDetailDialog(messageEl, errorDetail) })
+    } catch (err) {
+      console.error(err);
+    }
   }
   alert.toast();
 }
@@ -45,12 +50,22 @@ function escapeHtml(html) {
   return div.innerHTML;
 }
 
-function createMoreDetailDialog(messageEl, error) {
+function createMoreDetailDialog(messageEl, providedError) {
   // Dialog element
   const dialog = document.createElement('sl-dialog');
   dialog.label = 'Error details'
   dialog.classList.add("error-dialog");
   dialog.classList.add('above-toasts') // Dialogs usually sit below toasts in terms of z-index. This class styles them to sit above.
+
+  let error = new Error(providedError);
+
+  if (providedError instanceof Error) {
+    error = providedError
+  }
+
+  if (providedError.error) {
+    error = new Error(providedError.error);
+  }
 
   // Limit stack trace
   const maxLines = 4;

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -96,7 +96,7 @@ class PkgController {
       callbacks,
       actionType,
       pupId
-    })
+    });
   }
 
   resolveAction(txn, payload) {
@@ -165,11 +165,16 @@ class PkgController {
     const actionType = 'UPDATE-PUP';
 
     // Make a network call
+    console.log('HERE');
     const res = await postConfig(pupId, newData).catch((err) => {
+      console.log('ERR');
       console.error(err);
     });
 
+    console.log('HERE2');
+
     if (!res || res.error) {
+      console.log('THERE');
       callbacks.onError({ error: true, message: 'failure occured when calling postConfig' });
       return false;
     }
@@ -178,6 +183,7 @@ class PkgController {
     const txn = res.id
     if (txn && callbacks) {
       // Register transaction in actions register.
+      console.log('TXN', txn);
       this.registerAction(txn, callbacks, actionType, pupId)
     }
 

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -1,4 +1,4 @@
-import { postConfig } from '/api/config/config.js';
+import { postConfig } from "/api/config/config.js";
 
 class PkgController {
   observers = [];
@@ -36,23 +36,25 @@ class PkgController {
   }
 
   setData(bootstrapResponse) {
-    const { installed, available } = toAssembledPup(bootstrapResponse)
-    this.installed = toArray(installed)
+    const { installed, available } = toAssembledPup(bootstrapResponse);
+    this.installed = toArray(installed);
     this.available = toArray(available);
     this.packages = [...toArray(available), ...toArray(installed)];
-    this.pupIndex = { ...available, ...installed }
+    this.pupIndex = { ...available, ...installed };
     this.notify();
   }
 
   getPup(id) {
-    if (!id) return
-    const key = Object.keys(this.pupIndex).find(key => key.toLowerCase() === id.toLowerCase());
-    return this.pupIndex[key]
+    if (!id) return;
+    const key = Object.keys(this.pupIndex).find(
+      (key) => key.toLowerCase() === id.toLowerCase(),
+    );
+    return this.pupIndex[key];
   }
 
   installPkg(pupId) {
     // Find the pup in the available list
-    const index = this.available.findIndex(pup => pup.manifest.id === pupId);
+    const index = this.available.findIndex((pup) => pup.manifest.id === pupId);
     if (index !== -1) {
       // Move the pup from the available list to the installed list
       const [pup] = this.available.splice(index, 1);
@@ -63,7 +65,7 @@ class PkgController {
 
   removePkg(pupId) {
     // Find the pup in the installed list
-    const index = this.installed.findIndex(pup => pup.id === pupId);
+    const index = this.installed.findIndex((pup) => pup.id === pupId);
     if (index !== -1) {
       // Remove the pup from the installed list
       this.installed.splice(index, 1);
@@ -73,21 +75,28 @@ class PkgController {
 
   registerAction(txn, callbacks, actionType, pupId) {
     if (!txn || !callbacks || !actionType || !pupId) {
-      console.warn(`
+      console.warn(
+        `
         pkgController: MALFORMED REGISTER ACTION REQUEST.
         Expecting: txn, callbacks, actionType & pupId`,
-        { txn, callbacks, actionType, pupId }
-      )
+        { txn, callbacks, actionType, pupId },
+      );
       return;
     }
 
-    if (typeof callbacks.onSuccess !== 'function') {
-      console.warn('pkgController: ACTION SUCCESS CALLBACK NOT A FUNCTION.', { txn, callbacks })
+    if (typeof callbacks.onSuccess !== "function") {
+      console.warn("pkgController: ACTION SUCCESS CALLBACK NOT A FUNCTION.", {
+        txn,
+        callbacks,
+      });
       return;
     }
 
-    if (typeof callbacks.onError !== 'function') {
-      console.warn('pkgController: ACTION ERROR CALLBACK NOT A FUNCTION.', { txn, callbacks })
+    if (typeof callbacks.onError !== "function") {
+      console.warn("pkgController: ACTION ERROR CALLBACK NOT A FUNCTION.", {
+        txn,
+        callbacks,
+      });
       return;
     }
 
@@ -95,14 +104,14 @@ class PkgController {
       txn,
       callbacks,
       actionType,
-      pupId
+      pupId,
     });
   }
 
   resolveAction(txn, payload) {
-    const foundAction = this.actions.find(action => action.txn === txn);
+    const foundAction = this.actions.find((action) => action.txn === txn);
     if (!foundAction) {
-      console.warn('pkgController: ACTION NOT FOUND.', { txn })
+      console.warn("pkgController: ACTION NOT FOUND.", { txn });
       return;
     }
 
@@ -111,7 +120,7 @@ class PkgController {
       try {
         foundAction.callbacks.onError(payload);
       } catch (err) {
-        console.warn('the provided onError callback function threw an error');
+        console.warn("the provided onError callback function threw an error");
       }
       return;
     }
@@ -120,11 +129,11 @@ class PkgController {
     try {
       foundAction.callbacks.onSuccess(payload);
     } catch (err) {
-      console.warn('the provided onSuccess callback function threw an error');
+      console.warn("the provided onSuccess callback function threw an error");
     }
 
     switch (foundAction.actionType) {
-      case 'UPDATE-PUP':
+      case "UPDATE-PUP":
         this.updatePupModel(foundAction.pupId, payload.update);
         break;
     }
@@ -147,8 +156,8 @@ class PkgController {
         ...indexedPup,
         state: {
           ...indexedPup.state,
-          ...newPupStateData
-        }
+          ...newPupStateData,
+        },
       };
     }
 
@@ -157,34 +166,33 @@ class PkgController {
   }
 
   async requestPupChanges(pupId, newData, callbacks) {
-
     if (!pupId || !newData || !callbacks) {
-      console.warn('Error. requestPupChanges expected pupId, newData, callbacks', { pupId, newData, callbacks});
+      console.warn(
+        "Error. requestPupChanges expected pupId, newData, callbacks",
+        { pupId, newData, callbacks },
+      );
     }
 
-    const actionType = 'UPDATE-PUP';
+    const actionType = "UPDATE-PUP";
 
     // Make a network call
-    console.log('HERE');
     const res = await postConfig(pupId, newData).catch((err) => {
-      console.log('ERR');
       console.error(err);
     });
 
-    console.log('HERE2');
-
     if (!res || res.error) {
-      console.log('THERE');
-      callbacks.onError({ error: true, message: 'failure occured when calling postConfig' });
+      callbacks.onError({
+        error: true,
+        message: "failure occured when calling postConfig",
+      });
       return false;
     }
 
     // Submitting changes succeeded, carry on.
-    const txn = res.id
+    const txn = res.id;
     if (txn && callbacks) {
       // Register transaction in actions register.
-      console.log('TXN', txn);
-      this.registerAction(txn, callbacks, actionType, pupId)
+      this.registerAction(txn, callbacks, actionType, pupId);
     }
 
     // Return truthy to caller
@@ -205,14 +213,14 @@ function getInstance() {
 export const pkgController = getInstance();
 
 function toAssembledPup(bootstrapResponse) {
-  const sources = Object.keys(bootstrapResponse.manifests)
-  const states = bootstrapResponse.states
+  const sources = Object.keys(bootstrapResponse.manifests);
+  const states = bootstrapResponse.states;
   const stateKeys = Object.keys(states);
   const out = {
     internal: {},
     installed: {},
     available: {},
-  }
+  };
 
   // Populate available index.
   sources.forEach((source) => {
@@ -224,25 +232,25 @@ function toAssembledPup(bootstrapResponse) {
         state: {
           id: m.id,
           package: m.package,
-          ...defaultPupState()
+          ...defaultPupState(),
         },
-      }
-    })
-  })
+      };
+    });
+  });
 
   // Popupate installed index.
   Object.values(states).forEach((s) => {
     out.installed[s.id] = {
       computed: generateComputedVals(out.available[s.id].manifest),
       manifest: out.available[s.id].manifest,
-      state: s
-    }
-  })
+      state: s,
+    };
+  });
 
   // Remove installed pups from available index.
-  stateKeys.forEach(k => {
+  stateKeys.forEach((k) => {
     delete out.available[k];
-  })
+  });
   return out;
 }
 
@@ -254,8 +262,8 @@ function defaultPupState() {
   return {
     status: undefined,
     stats: undefined,
-    config: {}
-  }
+    config: {},
+  };
 }
 
 function generateComputedVals(m) {
@@ -268,5 +276,5 @@ function generateComputedVals(m) {
       library: `/pups/${id}/${name}`,
       store: `/explore/${id}/${name}`,
     },
-  }
+  };
 }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -78,6 +78,28 @@ class PupPage extends LitElement {
     this.open_dialog_label = el.getAttribute("label");
   };
 
+  submitConfig = async (stagedChanges, formNode, dynamicForm) => {
+    // Define callbacks
+    const callbacks = {
+      onSuccess: () => dynamicForm.commitChanges(formNode),
+      onError: (errorPayload) => {
+        dynamicForm.retainChanges(); // To cease the form from spinning
+        this.displayConfigUpdateErr(errorPayload); // Display a failure banner
+      }
+    }
+
+    // Invoke pkgContrller model update, supplying data and callbacks
+    const pkgId = this.context.store.pupContext.manifest.package
+    const res = await pkgController.requestPupChanges(pkgId, stagedChanges, callbacks);
+    if (res && !res.error) return true;
+  }
+
+  displayConfigUpdateErr(failedTxnPayload) {
+    const failedTxnId = failedTxnPayload?.id ? `(${failedTxnPayload.id})` : '';
+    createAlert('danger', ['Failed to update Pup configuration', `Refer to logs ${failedTxnId}`], 'exclamation-diamond');
+    console.warn(`Doge is sad because ${failedTxnId}: `, failedTxnPayload)
+  }
+
   render() {
     const path = this.context.store?.appContext?.path || [];
     const pkg = this.context.store.pupContext;

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -7,6 +7,7 @@ export function renderDialog() {
     <dynamic-form
       .values=${pkg?.state?.config}
       .fields=${pkg?.manifest?.command?.config}
+      .onSubmit=${this.submitConfig}
       requireCommit
       markModifiedFields
       allowDiscardChanges

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -1,8 +1,12 @@
-import { html, choose, unsafeHTML } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import {
+  html,
+  choose,
+  unsafeHTML,
+} from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderDialog() {
-  const pkg = this.context.store.pupContext
-  const readmeEl = html`${unsafeHTML(pkg?.manifest?.docs?.about)}`
+  const pkg = this.pkgController.getPup(this.pupId);
+  const readmeEl = html`${unsafeHTML(pkg?.manifest?.docs?.about)}`;
   const configEl = html`
     <dynamic-form
       .values=${pkg?.state?.config}
@@ -13,13 +17,17 @@ export function renderDialog() {
       allowDiscardChanges
     >
     </dynamic-form>
-  `
+  `;
 
   return html`
-    ${choose(this.open_dialog, [
-      ['readme', () => readmeEl],
-      ['configure', () => configEl]
-    ],
-    () => html`<span>View not provided: ${this.open_dialog}</span>`)}
-  `
+    ${choose(
+      this.open_dialog,
+      [
+        ["readme", () => readmeEl],
+        ["configure", () => configEl],
+      ],
+      () => html`<span>View not provided: ${this.open_dialog}</span>`,
+    )}
+  `;
 }
+


### PR DESCRIPTION
Pup config can be edited from the pup page.

This PR:
- Ensures the pup page uses the pkgController to read its pup state.
- Ensures the pup page has a pupId set, so that it is notified by the pkgController on state change
- Defines the submit handler for updating pup config from the pup page
- Utilises alert component on error;

In addition, prettier was ran across touched files.

On success:
![pup-page-updating-config-success](https://github.com/user-attachments/assets/6eed729f-a8d4-45c8-aa10-37d07405788a)

On error:
![pup-page-updating-config-error](https://github.com/user-attachments/assets/d113a2f5-3060-4aca-8342-d6147f7788ec)
