### PR TITLE
Status and Buttons 

### DIFF
--- a/src/api/action/action.js
+++ b/src/api/action/action.js
@@ -2,15 +2,33 @@ import ApiClient from '/api/client.js';
 import { store } from '/state/store.js'
 
 import { 
-  mock,
+  startMock,
+  installMock,
 } from './action.mocks.js'
 
 const client = new ApiClient('http://localhost:3000', store.networkContext)
 
 export async function stopPup(pupId, body) {
-  return client.post(`/action/${pupId}/stop`, body, { mock });
+  return client.post(`/action/${pupId}/stop`, body, { mock: startMock });
 }
 
 export async function startPup(pupId, body) {
-  return client.post(`/action/${pupId}/start`, body, { mock });
+  return client.post(`/action/${pupId}/start`, body, { mock: startMock });
+}
+
+export async function installPup(pupId, body) {
+  return client.post(`/action/${pupId}/install`, body, { mock: installMock });
+}
+
+export function pickAndPerformPupAction(pupId, action) {
+  switch(action) {
+    case 'install':
+      return installPup(pupId);
+      break;
+    case 'start':
+      return startPup(pupId);
+      break;
+    default:
+      console.warn('unsupported pup action requested', action);
+  }
 }

--- a/src/api/action/action.js
+++ b/src/api/action/action.js
@@ -28,6 +28,9 @@ export function pickAndPerformPupAction(pupId, action) {
     case 'start':
       return startPup(pupId);
       break;
+    case 'stop':
+      return stopPup(pupId);
+      break;
     default:
       console.warn('unsupported pup action requested', action);
   }

--- a/src/api/action/action.mocks.js
+++ b/src/api/action/action.mocks.js
@@ -1,19 +1,19 @@
-const postResponse = [
-  // When successful
-  {
-    success: true,
-    message: "Winner winner, chicken dinner",
-  },
-  // When fail
-  {
-    message: "Loser loser, tofu bruiser",
-    errors: [1,2,3]
-  }
-];
+const postResponse = {
+  success: true,
+  message: "Winner winner, chicken dinner",
+  id: 123,
+}
 
-export const mock = {
+export const startMock = {
   name: '/action/:pup/start',
-  method: 'get',
+  method: 'post',
+  group: 'pup actions',
+  res: postResponse
+}
+
+export const installMock = {
+  name: '/action/:pup/install',
+  method: 'post',
   group: 'pup actions',
   res: postResponse
 }

--- a/src/api/bootstrap/bootstrap.mocks.js
+++ b/src/api/bootstrap/bootstrap.mocks.js
@@ -20,7 +20,7 @@ function generateStates(manifests) {
         status: ['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar', 'ShibeShop'].includes(p.package) ? 'running' : 'stopped',
         stats: generateRandomStats(),
         config: generateConfigOptions(p.command.config),
-        installation: "unready",
+        installation: "ready",
         enabled: !!['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar'].includes(p.package),
         needs_deps: false,
         needs_config: false,

--- a/src/api/bootstrap/bootstrap.mocks.js
+++ b/src/api/bootstrap/bootstrap.mocks.js
@@ -12,14 +12,18 @@ export function generateBootstrap(input) {
 function generateStates(manifests) {
   const sources = [...manifests.local.available, ...manifests.internal.available]
   return sources.reduce((out, p) => {
-    if (['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar'].includes(p.package)) {
+    if (['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar', 'ShibeShop'].includes(p.package)) {
       out[p.package] = {
         id: p.id,
         package: p.package,
         source: 'local',
-        status: ['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar'].includes(p.package) ? 'running' : 'stopped',
+        status: ['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar', 'ShibeShop'].includes(p.package) ? 'running' : 'stopped',
         stats: generateRandomStats(),
-        config: generateConfigOptions(p.command.config)
+        config: generateConfigOptions(p.command.config),
+        installation: "unready",
+        enabled: !!['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar'].includes(p.package),
+        needs_deps: false,
+        needs_config: false,
       };
     }
     return out;

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -28,7 +28,6 @@ export default class ApiClient {
     const hasMock = !!config.mock
     const useMocks = this.networkContext.useMocks
     const specificMockEnabled = hasMock && useMocks && isMockEnabled(config.mock.group, config.mock.name, config.mock.method, this.networkContext)
-
     if (useMocks && hasMock && specificMockEnabled) {
       return await returnMockedResponse(path, config, this.networkContext)
     }

--- a/src/api/mocks.js
+++ b/src/api/mocks.js
@@ -1,4 +1,4 @@
-import { mock as actionMocks } from "./action/action.mocks.js"
+import { startMock, installMock } from "./action/action.mocks.js"
 import { mock as bootstrapMocks } from "./bootstrap/bootstrap.mocks.js"
 import { postResponse as pupConfigPost, getResponse as pupConfigGetById, getAllResponse as pupConfigGetAll } from "./config/config.mocks.js";
 import { getResponse as dkmGet } from "./keys/get-keylist.mocks.js";
@@ -12,7 +12,8 @@ import { getResponse as apModeFacts } from "./setup/get-bootstrap.mocks.js";
 
 export const mocks = [
   bootstrapMocks,
-  actionMocks,
+  startMock,
+  installMock,
   pupConfigGetAll,
   pupConfigGetById,
   pupConfigPost,

--- a/src/api/mocks/pup-state-cycle.js
+++ b/src/api/mocks/pup-state-cycle.js
@@ -1,0 +1,61 @@
+import { asyncTimeout } from "/utils/timeout.js";
+
+const msg = {
+  "id": "",
+  "error": "",
+  "type": "status",
+  "update": {}
+}
+
+function asStatusUpdate(pupId, newState) {
+  const out = { ...msg }
+  out.update[pupId] = {
+    installation: newState[0],
+    status: newState[1]
+  }
+  console.log('OUT!', out);
+  return out;
+}
+
+export async function performMockCycle(cycle, fn) {
+  for (let i = 0; i < cycle.length; i++) {
+    await asyncTimeout(3000);
+    await fn(asStatusUpdate("ShibeShop", cycle[i]));
+  }
+}
+
+export const c1 = [
+  ["installing", ""],
+  ["installing", ""],
+  ["installed", "starting"],
+  ["installed", "enabled"],
+];
+
+export const c2 = [
+  ["", ""],
+  ["installing", ""],
+  ["installed", "configure"],
+];
+
+export const c3 = [
+  ["", ""],
+  ["installing", ""],
+  ["installed", "configure"],
+];
+
+export const c4 = [
+  ["", ""],
+  ["installing", ""],
+  ["broken", ""],
+  ["installed", "needs_config"],
+  ["installed", "starting"],
+  ["installed", "enabled"],
+  ["installed", "stopping"],
+  ["installed", "disabled"],
+];
+
+export const c5 = [
+  ["installed", "starting"],
+  ["installed", "starting"],
+  ["installed", "enabled"],
+]

--- a/src/api/mocks/pup-state-cycle.js
+++ b/src/api/mocks/pup-state-cycle.js
@@ -13,49 +13,49 @@ function asStatusUpdate(pupId, newState) {
     installation: newState[0],
     status: newState[1]
   }
-  console.log('OUT!', out);
   return out;
 }
 
 export async function performMockCycle(cycle, fn) {
   for (let i = 0; i < cycle.length; i++) {
-    await asyncTimeout(3000);
+    await asyncTimeout(8000);
     await fn(asStatusUpdate("ShibeShop", cycle[i]));
   }
 }
 
 export const c1 = [
+  ["", ""],
   ["installing", ""],
-  ["installing", ""],
-  ["installed", "starting"],
-  ["installed", "enabled"],
+  ["unready", ""],
+  ["ready", ""]
 ];
 
 export const c2 = [
   ["", ""],
   ["installing", ""],
-  ["installed", "configure"],
+  ["ready", "configure"],
 ];
 
 export const c3 = [
   ["", ""],
   ["installing", ""],
-  ["installed", "configure"],
+  ["ready", "configure"],
 ];
 
 export const c4 = [
   ["", ""],
   ["installing", ""],
   ["broken", ""],
-  ["installed", "needs_config"],
-  ["installed", "starting"],
-  ["installed", "enabled"],
-  ["installed", "stopping"],
-  ["installed", "disabled"],
+  ["ready", "needs_config"],
+  ["ready", "starting"],
+  ["ready", "enabled"],
+  ["ready", "stopping"],
+  ["ready", "disabled"],
 ];
 
 export const c5 = [
-  ["installed", "starting"],
-  ["installed", "starting"],
-  ["installed", "enabled"],
+  ["ready", "starting"],
+  ["ready", "running"],
+  ["ready", "stopping"],
+  ["ready", "stopped"]
 ]

--- a/src/components/common/action-row/action-row.js
+++ b/src/components/common/action-row/action-row.js
@@ -10,6 +10,7 @@ class ActionRow extends LitElement {
       variant: { type: String },
       loading: { type: Boolean },
       href: { type: String },
+      disabled: { type: Boolean },
     };
   }
 
@@ -20,6 +21,7 @@ class ActionRow extends LitElement {
     this.suffix = "chevron-right";
     this.trigger = false;
     this.href = "";
+    this.disabled = false;
   }
 
   static styles = css`
@@ -64,9 +66,20 @@ class ActionRow extends LitElement {
       color: var(--sl-color-danger-800);
     }
     :host(:hover) {
-      color: var(--sl-color-neutral-950);
+      color: var(--sl-color-neutral-800);
       cursor: pointer;
     }
+
+    /* DISABLED STATE */
+    :host([disabled]) {
+      pointer-events: none;
+      color: var(--sl-color-neutral-400);
+    }
+
+    :host([disabled]:hover) {
+      color: var(--sl-color-neutral-400);
+    }
+
 
     .base-wrap {
       display: flex;
@@ -171,8 +184,9 @@ class ActionRow extends LitElement {
         </div>
 
         <div class="suffix-wrap" part="suffix">
-          <slot name="suffix"></slot>
-          <sl-icon name="chevron-right"></sl-icon>
+          <slot name="suffix">
+            <sl-icon name="chevron-right"></sl-icon>
+          </slot>
         </div>
       </div>
     `

--- a/src/components/views/x-check/index.js
+++ b/src/components/views/x-check/index.js
@@ -6,6 +6,7 @@ class HealthCheck extends LitElement {
     return {
       status: { type: String },
       check: { type: Object },
+      disabled: { type: Boolean }
     };
   }
 
@@ -13,13 +14,23 @@ class HealthCheck extends LitElement {
     super();
     this.check = {};
     this.status = "loading";
+    this.disabled = false;
   }
 
   determine(status) {
     let prefix = "";
     let variant = "";
 
+    if (this.disabled) {
+      status = "disabled"
+    }
+
     switch (status) {
+      case "disabled":
+        return {
+          prefix: "pause-circle",
+          variant: "neutral",
+        };
       case "success":
         return {
           prefix: "check2",
@@ -62,7 +73,8 @@ class HealthCheck extends LitElement {
         label="${check.label}"
         prefix=${this.determine(this.status).prefix}
         variant=${this.determine(this.status).variant}
-        ?loading=${this.status === "loading"}
+        ?loading=${!this.disabled && this.status === "loading"}
+        ?disabled=${this.disabled}
       >
         ${check.description}
       </action-row>

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -250,7 +250,6 @@ class PkgController {
 
   transactionTimeoutChecker() {
     setInterval(() => {
-      console.log(this.actions.length);
       if (this.actions.length === 0) return;
       this.actions.forEach((a) => {
         if (!a.expireAt) return;
@@ -340,8 +339,8 @@ function defaultPupState() {
 function generateComputedVals(m, s) {
   const id = encodeURIComponent(m.id.toLowerCase());
   const name = encodeURIComponent(m.package.toLowerCase());
-  const status = determineStatusId(s?.installation, s?.status);
-  const installation = determineInstallationId(s?.installation);
+  const status = determineStatusId(s);
+  const installation = determineInstallationId(s);
   return {
     id: m.id,
     url: {
@@ -356,7 +355,9 @@ function generateComputedVals(m, s) {
   };
 }
 
-function determineInstallationId(installation) {
+function determineInstallationId(state) {
+  const installation = state?.installation;
+
   if (!installation) {
     return { id: "not_installed", label: "not installed" };
   }
@@ -384,17 +385,20 @@ function determineInstallationId(installation) {
   return { id: "unknown", label: "unknown" };
 }
 
-function determineStatusId(installation, status) {
-  if (!installation) {
-    return { id: "not_installed", label: "not installed" };
+function determineStatusId(state) {
+  const installation = state?.installation;
+  const status = state?.status;
+  const flags = {
+    needs_deps: state?.needs_deps,
+    needs_config: state?.needs_config
   }
 
-  if (installation === "installing") {
-    return { id: "installing", label: "installing" };
+  if (flags.needs_deps) {
+    return { id: "needs_deps", label: "Missing Dependencies" };
   }
 
-  if (installation === "broken") {
-    return { id: "broken", label: "broken" };
+  if (flags.needs_config) {
+    return { id: "needs_config", label: "Needs Config" };
   }
 
   if (status === "starting") {

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -15,7 +15,7 @@ async function mockedMainChannelRunner(onMessageCallback) {
     }, 2000);
   }
 
-  if (true) {
+  if (store.networkContext.demoPupLifecycle) {
     await performMockCycle(c5, (statusUpdate) => onMessageCallback({ data: JSON.stringify(statusUpdate) }))
   }
 }

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -16,7 +16,7 @@ async function mockedMainChannelRunner(onMessageCallback) {
   }
 
   if (true) {
-    await performMockCycle(c1, (statusUpdate) => onMessageCallback({ data: JSON.stringify(statusUpdate) }))
+    await performMockCycle(c5, (statusUpdate) => onMessageCallback({ data: JSON.stringify(statusUpdate) }))
   }
 }
 

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -2,8 +2,9 @@ import WebSocketClient from "/api/sockets.js";
 import { store } from "/state/store.js";
 import { pkgController } from "/controllers/package/index.js";
 import { asyncTimeout } from "/utils/timeout.js";
+import { performMockCycle, c1, c4, c5 } from "/api/mocks/pup-state-cycle.js";
 
-function mockedMainChannelRunner(onMessageCallback) {
+async function mockedMainChannelRunner(onMessageCallback) {
   if (store.networkContext.demoSystemPrompt) {
     setTimeout(() => {
       const mockData = {
@@ -12,6 +13,10 @@ function mockedMainChannelRunner(onMessageCallback) {
       };
       onMessageCallback({ data: JSON.stringify(mockData) });
     }, 2000);
+  }
+
+  if (true) {
+    await performMockCycle(c1, (statusUpdate) => onMessageCallback({ data: JSON.stringify(statusUpdate) }))
   }
 }
 
@@ -50,7 +55,7 @@ class SocketChannel {
     };
 
     this.wsClient.onMessage = async (event) => {
-      console.log("MSSSGSG!~", event, event.data);
+      // console.log("MSSSGSG!~", event, event.data);
 
       let err, data;
       try {
@@ -70,11 +75,20 @@ class SocketChannel {
 
       switch (data.type) {
         case "PupStatus":
+          // A message of type PupStatus is received in response to a requested action resolving.
+
           // TODO: determine why.
           // Receiving completed txns before the txn has been registered in the client.
           await asyncTimeout(500);
 
           pkgController.resolveAction(data.id, data);
+          break;
+        case "status":
+          // A message of type "status" is received when dogeboxd broadcasts status changes
+          // Changes include cpu, mem, running states etc..
+          Object.keys(data.update).forEach((pupId) => {
+            pkgController.updatePupModel(pupId, data.update[pupId])
+          });
           break;
         case "ShowPrompt":
           store.updateState({

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -126,8 +126,10 @@ class PupPage extends LitElement {
 
   render() {
     const path = this.context.store?.appContext?.path || [];
-    const pkg = this.context.store.pupContext;
+    const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+    const { statusId, statusLabel } = pkg.computed
     const hasChecks = (pkg?.manifest?.checks || []).length > 0;
+    const isLoadingStatus =  ["starting", "stopping", "crashing"].includes(statusId);
 
     const renderHealthChecks = () => {
       return this.checks.map(
@@ -136,6 +138,14 @@ class PupPage extends LitElement {
         `,
       );
     };
+
+    const renderStatusAndActions = () => {
+      return html`
+        ${this.renderStatus()}
+        <sl-progress-bar value="0" ?indeterminate=${isLoadingStatus} class="loading-bar"></sl-progress-bar>
+        ${this.renderActions()}
+      `
+    }
 
     const renderMenu = () => html`
       <action-row
@@ -182,8 +192,7 @@ class PupPage extends LitElement {
           <div class="section-title">
             <h3>Status</h3>
           </div>
-          <div class="underscored">${this.renderStatus()}</div>
-          <div>${this.renderActions()}</div>
+          ${renderStatusAndActions()}
         </section>
 
         ${hasChecks
@@ -222,6 +231,7 @@ class PupPage extends LitElement {
     :host {
       position: relative;
       display: block;
+      --indi: #777;
     }
 
     .wrapper {
@@ -269,6 +279,11 @@ class PupPage extends LitElement {
     sl-dialog.distinct-header::part(header) {
       z-index: 960;
       background: rgb(24, 24, 24);
+    }
+
+    .loading-bar {
+      --height: 1px;
+      --track-color: #444;
     }
   `;
 }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -284,6 +284,7 @@ class PupPage extends LitElement {
     .loading-bar {
       --height: 1px;
       --track-color: #444;
+      --indicator-color: #999;
     }
   `;
 }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -37,6 +37,7 @@ class PupPage extends LitElement {
     this.open_page = false;
     this.open_page_label = "";
     this.checks = [];
+    this.pupEnabled = false;
   }
 
   connectedCallback() {
@@ -44,6 +45,7 @@ class PupPage extends LitElement {
     // Observers with a pupId will be requested to
     // update when state for that pup changes
     this.pupId = this.context.store.pupContext.manifest.id;
+    this.pupEnabled = this.pkgController.getPup(this.pupId)?.state?.enabled
     this.pkgController.addObserver(this);
   }
 
@@ -56,8 +58,7 @@ class PupPage extends LitElement {
     this.addEventListener("sl-hide", this.handleDialogClose);
     this.checks = this.context.store.pupContext?.manifest?.checks;
 
-    const pkgId = this.context.store.pupContext.manifest.package;
-    if (pkgId === "Core") {
+    if (this.pupId === "Core") {
       await asyncTimeout(1200);
       this.checks[1].status = "success";
       this.requestUpdate();
@@ -93,9 +94,8 @@ class PupPage extends LitElement {
     };
 
     // Invoke pkgContrller model update, supplying data and callbacks
-    const pkgId = this.context.store.pupContext.manifest.id;
     const res = await pkgController.requestPupChanges(
-      pkgId,
+      this.pupId,
       stagedChanges,
       callbacks,
     );
@@ -124,6 +124,20 @@ class PupPage extends LitElement {
     );
   }
 
+  async handleStartStop(e) {
+    this.inflight = true;
+    this.pupEnabled = e.target.checked;
+    this.requestUpdate();
+
+    const actionName = e.target.checked ? 'start' : 'stop' ;
+    const callbacks = {
+      onSuccess: () => console.log('WOW'),
+      onError: () => console.log('NOO..'),
+      onTimeout: () => { console.log('TOO SLOW..'); this.inflight = false; }
+    }
+    await this.pkgController.requestPupAction(this.pupId, actionName, callbacks);
+  }
+
   render() {
     const path = this.context.store?.appContext?.path || [];
     const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
@@ -134,7 +148,7 @@ class PupPage extends LitElement {
     const renderHealthChecks = () => {
       return this.checks.map(
         (check) => html`
-          <health-check status=${check.status} .check=${check}></health-check>
+          <health-check status=${check.status} .check=${check} ?disabled=${!this.pupEnabled}></health-check>
         `,
       );
     };
@@ -142,49 +156,43 @@ class PupPage extends LitElement {
     const renderStatusAndActions = () => {
       return html`
         ${this.renderStatus()}
-        <sl-progress-bar value="0" ?indeterminate=${isLoadingStatus} class="loading-bar"></sl-progress-bar>
+        <sl-progress-bar value="0" ?indeterminate=${isLoadingStatus} class="loading-bar ${statusId}"></sl-progress-bar>
         ${this.renderActions()}
       `
     }
 
     const renderMenu = () => html`
-      <action-row
-        prefix="list-ul"
-        name="readme"
-        label="Read me"
-        .trigger=${this.handleMenuClick}
-      >
-        Many info
+      <action-row prefix="power" name="state" label="Enabled">
+        Enable or disable this Pup
+        <sl-switch slot="suffix" ?checked=${pkg.state.enabled} @sl-input=${this.handleStartStop}></sl-switch>
       </action-row>
 
-      <action-row
-        prefix="gear"
-        name="configure"
-        label="Configure"
-        .trigger=${this.handleMenuClick}
-      >
+      <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick}>
         Customize ${pkg.manifest.package}
       </action-row>
 
-      <!--action-row prefix="archive-fill" name="properties" label="Properties" .trigger=${this
-        .handleMenuClick}>
+      <!--action-row prefix="archive-fill" name="properties" label="Properties" .trigger=${this.handleMenuClick}>
         Ea sint dolor commodo.
       </action-row-->
 
-      <!--action-row prefix="lightning-charge" name="actions" label="Actions" .trigger=${this
-        .handleMenuClick}>
+      <!--action-row prefix="lightning-charge" name="actions" label="Actions" .trigger=${this.handleMenuClick}>
         Ea sint dolor commodo.
       </action-row-->
 
-      <action-row
-        prefix="display"
-        name="logs"
-        label="Logs"
-        href="${window.location.pathname}/logs"
-      >
+      <action-row prefix="display" name="logs" label="Logs" href="${window.location.pathname}/logs">
         Unfiltered logs
       </action-row>
     `;
+
+    const renderMore = () => html`
+      <action-row prefix="list-ul" name="readme" label="Read me" .trigger=${this.handleMenuClick}>
+        Many info
+      </action-row>
+
+      <action-row prefix="box-seam" name="deps" label="Dependencies" .trigger=${this.handleMenuClick}>
+        View software this Pup depends on
+      </action-row>
+    `
 
     return html`
       <div id="PageWrapper" class="wrapper">
@@ -195,22 +203,27 @@ class PupPage extends LitElement {
           ${renderStatusAndActions()}
         </section>
 
-        ${hasChecks
-          ? html`
-              <section>
-                <div class="section-title">
-                  <h3>Health checks</h3>
-                </div>
-                <div class="list-wrap">${renderHealthChecks()}</div>
-              </section>
-            `
-          : nothing}
-
         <section>
           <div class="section-title">
             <h3>Menu</h3>
           </div>
           <div class="list-wrap">${renderMenu()}</div>
+        </section>
+
+        ${hasChecks ? html`
+        <section>
+          <div class="section-title">
+            <h3>Health checks</h3>
+          </div>
+          <div class="list-wrap">${renderHealthChecks()}</div>
+        </section>`
+        : nothing }
+
+        <section>
+          <div class="section-title">
+            <h3>Such More</h3>
+          </div>
+          <div class="list-wrap">${renderMore()}</div>
         </section>
       </div>
 
@@ -285,6 +298,8 @@ class PupPage extends LitElement {
       --height: 1px;
       --track-color: #444;
       --indicator-color: #999;
+      &.starting { --indicator-color: var(--sl-color-primary-600); }
+      &.stopping { --indicator-color: var(--sl-color-danger-600); }
     }
   `;
 }

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -36,36 +36,31 @@ export function renderActions() {
         </sl-button>
       ` : nothing }
 
-      ${status === 'enabled' ? html`
+      ${status === 'running' ? html`
         <sl-button variant="danger" size="large">
           <sl-icon slot="prefix" name="stop-fill"></sl-icon>
           Disable
         </sl-button>
-        <sl-button variant="primary" size="large">
-          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-          Restart
+      ` : nothing }
+
+      ${status === 'starting' ? html`
+        <sl-button variant="success" size="large" disabled>
+          <sl-icon slot="prefix" name="play-fill"></sl-icon>
+          Enable
         </sl-button>
       ` : nothing }
 
-      ${status === 'starting' || status === 'stopping' ? html`
+      ${status === 'stopping' ? html`
         <sl-button variant="danger" size="large" disabled>
           <sl-icon slot="prefix" name="stop-fill"></sl-icon>
           Disable
         </sl-button>
-        <sl-button variant="primary" size="large" disabled>
-          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-          Restart
-        </sl-button>
       ` : nothing }
 
-      ${status === 'disabled' ? html`
-        <sl-button variant="primary" size="large">
+      ${status === 'stopped' ? html`
+        <sl-button variant="success" size="large">
           <sl-icon slot="prefix" name="play-fill"></sl-icon>
           Enable
-        </sl-button>
-        <sl-button variant="primary" size="large" disable>
-          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
-          Restart
         </sl-button>
       ` : nothing }
 

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -6,13 +6,15 @@ export function openConfig() {
 }
 
 export function renderActions() {
-  const pkg = this.context.store.pupContext;
+  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const { statusId, statusLabel } = pkg.computed
   const styles = css`
     .action-wrap {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       gap: 1em;
+      margin-top: 1.2em;
     }
 
     .show-only-wide {
@@ -22,12 +24,19 @@ export function renderActions() {
       }
     }
   `
-  const status = 'RUNNING' || pkg.state.status;
+  const status = statusId;
 
   return html`
     <div class="action-wrap">
 
-      ${status === 'RUNNING' ? html`
+      ${statusId === 'needs_config' ? html`
+        <sl-button variant="warning" size="large" @click=${this.openConfig}>
+          <sl-icon slot="prefix" name="gear"></sl-icon>
+          Configure
+        </sl-button>
+      ` : nothing }
+
+      ${status === 'enabled' ? html`
         <sl-button variant="danger" size="large">
           <sl-icon slot="prefix" name="stop-fill"></sl-icon>
           Disable
@@ -38,17 +47,25 @@ export function renderActions() {
         </sl-button>
       ` : nothing }
 
-      ${status === 'NEEDS_CONFIG' ? html`
-        <sl-button variant="warning" size="large" @click=${this.openConfig}>
-          <sl-icon slot="prefix" name="gear"></sl-icon>
-          Configure
+      ${status === 'starting' || status === 'stopping' ? html`
+        <sl-button variant="danger" size="large" disabled>
+          <sl-icon slot="prefix" name="stop-fill"></sl-icon>
+          Disable
+        </sl-button>
+        <sl-button variant="primary" size="large" disabled>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Restart
         </sl-button>
       ` : nothing }
 
-      ${status === 'UNMET_DEP' ? html`
-        <sl-button variant="warning" size="large">
-          <sl-icon slot="prefix" name="stop-fill"></sl-icon>
-          Configure
+      ${status === 'disabled' ? html`
+        <sl-button variant="primary" size="large">
+          <sl-icon slot="prefix" name="play-fill"></sl-icon>
+          Enable
+        </sl-button>
+        <sl-button variant="primary" size="large" disable>
+          <sl-icon slot="prefix" name="arrow-clockwise"></sl-icon>
+          Restart
         </sl-button>
       ` : nothing }
 

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -55,7 +55,7 @@ export function renderActions() {
           ${statusId === 'needs_config' || statusId === 'needs_deps' ? html`
           <sl-divider class="show-only-wide" vertical style="height: 1.5em; margin-left: 0.1em;"></sl-divider>
           `: nothing}
-          <sl-button size="large" variant="warning" href="${pkg.computed.url.gui}"} ?disabled="${installationId !== "unready" }">
+          <sl-button size="large" variant="warning" href="${pkg.computed.url.gui}"} ?disabled="${installationId !== "ready" }">
             <sl-icon slot="prefix" name="stars"></sl-icon>
             Launch UI
           </sl-button>

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -5,16 +5,25 @@ export function openConfig() {
   this.open_dialog_label = "Configure";
 }
 
+export function openDeps() {
+  this.open_dialog = "deps";
+  this.open_dialog_label = "Dependencies";
+}
+
 export function renderActions() {
   const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
-  const { statusId, statusLabel } = pkg.computed
+  const { installationId, statusId, statusLabel } = pkg.computed
+  const hasButtons =  ["needs_deps", "needs_config"].includes(statusId) || pkg.manifest.gui;
   const styles = css`
     .action-wrap {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       gap: 1em;
-      margin-top: 1.2em;
+
+      &.margin {
+        margin-top: 1.2em;
+      }
     }
 
     .show-only-wide {
@@ -24,10 +33,9 @@ export function renderActions() {
       }
     }
   `
-  const status = statusId;
 
   return html`
-    <div class="action-wrap">
+    <div class="action-wrap ${hasButtons ? "margin" : ""}">
 
       ${statusId === 'needs_config' ? html`
         <sl-button variant="warning" size="large" @click=${this.openConfig}>
@@ -36,39 +44,19 @@ export function renderActions() {
         </sl-button>
       ` : nothing }
 
-      ${status === 'running' ? html`
-        <sl-button variant="danger" size="large">
-          <sl-icon slot="prefix" name="stop-fill"></sl-icon>
-          Disable
-        </sl-button>
-      ` : nothing }
-
-      ${status === 'starting' ? html`
-        <sl-button variant="success" size="large" disabled>
-          <sl-icon slot="prefix" name="play-fill"></sl-icon>
-          Enable
-        </sl-button>
-      ` : nothing }
-
-      ${status === 'stopping' ? html`
-        <sl-button variant="danger" size="large" disabled>
-          <sl-icon slot="prefix" name="stop-fill"></sl-icon>
-          Disable
-        </sl-button>
-      ` : nothing }
-
-      ${status === 'stopped' ? html`
-        <sl-button variant="success" size="large">
-          <sl-icon slot="prefix" name="play-fill"></sl-icon>
-          Enable
+      ${statusId === 'needs_deps' ? html`
+        <sl-button variant="warning" size="large" name="deps" label="dependencies" @click=${this.openDeps}>
+          View List
         </sl-button>
       ` : nothing }
 
       ${pkg.manifest.gui ? html`
         <div style="display: flex; align-items: center;">
+          ${statusId === 'needs_config' || statusId === 'needs_deps' ? html`
           <sl-divider class="show-only-wide" vertical style="height: 1.5em; margin-left: 0.1em;"></sl-divider>
-          <sl-button variant="primary" size="large" outline href="/explore/${pkg.manifest.id.toLowerCase()}/ui" ?disabled=${status === "NEEDS_CONFIG"}>
-            <sl-icon slot="prefix" name="box-arrow-up-right"></sl-icon>
+          `: nothing}
+          <sl-button size="large" variant="warning" href="${pkg.computed.url.gui}"} ?disabled="${installationId !== "unready" }">
+            <sl-icon slot="prefix" name="stars"></sl-icon>
             Launch UI
           </sl-button>
         </div>

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -7,6 +7,13 @@ import {
 export function renderDialog() {
   const pkg = this.pkgController.getPup(this.pupId);
   const readmeEl = html`${unsafeHTML(pkg?.manifest?.docs?.about)}`;
+  const depsEl = pkg.manifest.deps.pups.length > 0 
+    ? pkg.manifest.deps.pups.map((dep) => html`
+      <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
+        ${dep.condition}
+      </action-row>`)
+    : html`<div style="padding: 1em; text-align: center;"> Such empty. This pup depends on no other.</div>`
+
   const configEl = html`
     <dynamic-form
       .values=${pkg?.state?.config}
@@ -24,6 +31,7 @@ export function renderDialog() {
       this.open_dialog,
       [
         ["readme", () => readmeEl],
+        ["deps", () => depsEl],
         ["configure", () => configEl],
       ],
       () => html`<span>View not provided: ${this.open_dialog}</span>`,

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -5,6 +5,10 @@ export function renderStatus() {
   const { statusId, statusLabel } = pkg.computed;
   const isLoadingStatus = ["starting", "stopping", "crashing"].includes(statusId);
   const styles = css`
+    :host {
+      --color-neutral: #8e8e9a;
+    }
+
     .status-label {
       font-size: 2em;
       line-height: 1.5;
@@ -12,29 +16,26 @@ export function renderStatus() {
       padding-bottom: 0.5rem;
       font-family: 'Comic Neue';
       text-transform: capitalize;
+      color: var(--color-neutral);
 
-      &.enabled {
-        color: #2ede75;
+      &.running {
+        color: var(--sl-color-success-500);
       }
 
       &.needs_config {
         color: var(--sl-color-amber-600);
       }
 
-      &.installing,
-      &.starting {
-        color: rgb(0, 195, 255);
+      &.starting,
+      &.stopping
+      &.stopped {
+        color: var(--color-neutral);
       }
 
-      &.stopping,
       &.broken {
-        color: #fe5c5c;
+        color: var(--sl-color-danger-500);
       }
 
-      &.disabled,
-      &.not_installed {
-        color: #8e8e9a;
-      }
     }
   `
 

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -18,24 +18,13 @@ export function renderStatus() {
       text-transform: capitalize;
       color: var(--color-neutral);
 
-      &.running {
-        color: var(--sl-color-success-500);
-      }
-
-      &.needs_config {
-        color: var(--sl-color-amber-600);
-      }
-
-      &.starting,
-      &.stopping
-      &.stopped {
-        color: var(--color-neutral);
-      }
-
-      &.broken {
-        color: var(--sl-color-danger-500);
-      }
-
+      &.needs_deps { color: var(--sl-color-amber-600); }
+      &.needs_config { color: var(--sl-color-amber-600); }
+      &.starting { color: var(--sl-color-primary-600); }
+      &.stopping { color: var(--sl-color-danger-600); }
+      &.stopped { color: var(--color-neutral); }
+      &.running { color: var(--sl-color-success-600); }
+      &.broken { color: var(--sl-color-danger-600);}
     }
   `
 

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -1,7 +1,9 @@
-import { html, css, classMap } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderStatus() {
-  const pkg = this.context.store.pupContext
+  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const { statusId, statusLabel } = pkg.computed;
+  const isLoadingStatus = ["starting", "stopping", "crashing"].includes(statusId);
   const styles = css`
     .status-label {
       font-size: 2em;
@@ -11,29 +13,35 @@ export function renderStatus() {
       font-family: 'Comic Neue';
       text-transform: capitalize;
 
-      &.running {
+      &.enabled {
         color: #2ede75;
       }
 
       &.needs_config {
         color: var(--sl-color-amber-600);
       }
+
+      &.installing,
+      &.starting {
+        color: rgb(0, 195, 255);
+      }
+
+      &.stopping,
+      &.broken {
+        color: #fe5c5c;
+      }
+
+      &.disabled,
+      &.not_installed {
+        color: #8e8e9a;
+      }
     }
   `
 
-  const status = 'RUNNING' || pkg.state.status;
-  const statusLabel = {
-    'RUNNING': 'enabled',
-    'NEEDS_CONFIG': 'needs config'
-  }
-
-  const statusClasses = classMap({
-    'running': status === 'RUNNING',
-    'needs_config': status === 'NEEDS_CONFIG',
-  });
-
   return html`
-    <span class="status-label ${statusClasses}">${statusLabel[status]}</span>
+    <span class="status-label ${statusId}">
+      ${statusLabel}
+    </span>
     <style>${styles}</style>
   `
 };

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -22,6 +22,8 @@ class PupInstallPage extends LitElement {
     return {
       open_dialog: { type: Boolean },
       open_dialog_label: { type: String },
+      busy: { type: Boolean },
+      inflight: { type: Boolean },
     };
   }
 
@@ -34,6 +36,8 @@ class PupInstallPage extends LitElement {
     this.open_dialog_label = "";
     this.open_page = false;
     this.open_page_label = "";
+    this.busy = false;
+    this.inflight = false;
   }
 
   connectedCallback() {
@@ -76,7 +80,7 @@ class PupInstallPage extends LitElement {
 
     const wrapperClasses = classMap({
       wrapper: true,
-      installed: statusId === 'installed',
+      installed: ["ready", "unready"].includes(installationId),
     });
 
     const renderStatusAndActions = () => {

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -73,7 +73,6 @@ class PupInstallPage extends LitElement {
     const path = this.context.store?.appContext?.path || [];
     const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
     const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
-    const isInstalled = installationId === "installed";
     const isLoadingStatus = ["installing"].includes(statusId);
     const hasDependencies = (pkg?.manifest?.deps?.pups || []).length > 0
     const popover_page = path[1];
@@ -82,14 +81,6 @@ class PupInstallPage extends LitElement {
       wrapper: true,
       installed: ["ready", "unready"].includes(installationId),
     });
-
-    const renderStatusAndActions = () => {
-      return html`
-        ${this.renderStatus()}
-        <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
-        ${this.renderActions()}
-      `
-    }
 
     const renderDependancyList = () => {
       return pkg.manifest.deps.pups.map((dep) => html`
@@ -102,10 +93,8 @@ class PupInstallPage extends LitElement {
     return html`
       <div id="PageWrapper" class="${wrapperClasses}" ?data-freeze=${popover_page}>
         <section class="status">
-          <div class="section-title">
-            <h3 class="installation-label ${installationId}">${installationLabel}</h3>
-          </div>
-          ${renderStatusAndActions()}
+          ${this.renderStatus()}
+          ${this.renderActions()}
         </section>
 
         <section>
@@ -195,31 +184,6 @@ class PupInstallPage extends LitElement {
       font-family: "Comic Neue";
     }
 
-    .wrapper section.status .section-title h3 {
-      font-weight: 100;
-      color: var(--sl-color-warning-700);
-
-      &.installing {
-        color: var(--sl-color-warning-700);
-      }
-
-      &.installed {
-        color: rgb(0, 195, 255);
-      }
-
-      &.broken {
-        color: #fe5c5c;
-      }
-    }
-
-    .wrapper.installed section.status .section-title h3 {
-      color: #00c3ff;
-    }
-
-    section div.underscored {
-      border-bottom: 1px solid #333;
-    }
-
     aside.page-popver {
       display: none;
       position: fixed;
@@ -253,11 +217,6 @@ class PupInstallPage extends LitElement {
       @media (min-width: 576px) {
         grid-template-columns: 1fr 1fr; /* Two columns of equal width */
       }
-    }
-
-    .loading-bar {
-      --indicator-color:var(--sl-color-amber-700);
-      --height: 1px;
     }
   `;
 }

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -1,4 +1,5 @@
 import { html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { installPup } from "/api/action/action.js";
 
 export function openConfig() {
   this.open_dialog = "configure";
@@ -27,7 +28,10 @@ export function renderActions() {
     <div class="action-wrap">
 
       ${installationId === "not_installed" ? html`
-        <sl-button variant="warning" size="large">
+        <sl-button variant="warning" size="large"
+          @click=${this.handleInstall}
+          ?disabled=${this.inflight}
+          ?loading=${this.inflight}>
           Such Install
         </sl-button>
       ` : nothing }
@@ -38,7 +42,7 @@ export function renderActions() {
         </sl-button>
       ` : nothing }
 
-      ${installationId === "installed" ? html`
+      ${["ready", "unready"].includes(installationId) ? html`
         <sl-button variant="primary" size="large" href="${pkg.computed.url.library}">
           Manage
         </sl-button>
@@ -48,3 +52,14 @@ export function renderActions() {
     <style>${styles}</style>
   `
 };
+
+export async function handleInstall() {
+  this.inflight = true;
+  const callbacks = {
+    onSuccess: () => console.log('WOW'),
+    onError: () => console.log('NOO..'),
+    onTimeout: () => { console.log('TOO SLOW..'); this.inflight = false; }
+  }
+  await this.pkgController.requestPupAction(this.pupId, 'install', callbacks);
+}
+

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -6,14 +6,15 @@ export function openConfig() {
 }
 
 export function renderActions() {
-  const pkg = this.context.store.pupContext;
-  console.log(pkg);
+  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
   const styles = css`
     .action-wrap {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
       gap: 1em;
+      margin-top: 1.2em;
 
       sl-button {
         min-width: 180px;
@@ -25,15 +26,21 @@ export function renderActions() {
   return html`
     <div class="action-wrap">
 
-      ${isInstalled ? html`
-        <sl-button variant="primary" size="large" href="${pkg.computed.url.library}">
-          Manage
+      ${installationId === "not_installed" ? html`
+        <sl-button variant="warning" size="large">
+          Such Install
         </sl-button>
       ` : nothing }
 
-      ${!isInstalled ? html`
-        <sl-button variant="warning" size="large">
-          Such Install
+      ${installationId === "installing" ? html`
+        <sl-button variant="warning" size="large" disabled>
+          Installing <sl-spinner slot="suffix" style="--indicator-color:#222"></sl-spinner>
+        </sl-button>
+      ` : nothing }
+
+      ${installationId === "installed" ? html`
+        <sl-button variant="primary" size="large" href="${pkg.computed.url.library}">
+          Manage
         </sl-button>
       ` : nothing }
 

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -1,5 +1,4 @@
 import { html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
-import { installPup } from "/api/action/action.js";
 
 export function openConfig() {
   this.open_dialog = "configure";

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -2,21 +2,46 @@ import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min
 
 export function renderStatus() {
   const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
-  const { statusId, statusLabel } = pkg.computed
-  const isLoadingStatus = ["installing"].includes(statusId);
-  const styles = css`
-    .status-label {
-      font-size: 2em;
-      line-height: 1.5;
-      display: block;
-      padding-bottom: 0.5rem;
-      font-family: 'Comic Neue';
-      text-transform: capitalize;
-    }
-  `
+  const { installationId, installationLabel } = pkg.computed
+  const isLoadingStatus = ["installing"].includes(installationId);
 
   return html`
-    <span class="status-label">${pkg.manifest.package}</span>
+    <div class="section-title">
+      <h3 class="installation-label ${installationId}">${installationLabel}</h3>
+    </div>
+    <div>
+      <span class="status-label">${pkg.manifest.package}</span>
+      <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
+    </div>
     <style>${styles}</style>
   `
 };
+
+const styles = css`
+  .status-label {
+    font-size: 2em;
+    line-height: 1.5;
+    display: block;
+    padding-bottom: 0.5rem;
+    font-family: 'Comic Neue';
+    text-transform: capitalize;
+  }
+
+  .loading-bar {
+    --indicator-color:var(--sl-color-amber-700);
+    --height: 1px;
+  }
+
+  .wrapper section.status .section-title h3 {
+    font-weight: 100;
+    color: var(--sl-color-warning-700);
+
+    &.installing { color: var(--sl-color-warning-700); }
+    &.installed { color: rgb(0, 195, 255); }
+    &.broken { color: #fe5c5c; }
+  }
+
+  .wrapper.installed section.status .section-title h3 {
+    color: #00c3ff;
+  }
+`

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -1,7 +1,9 @@
-import { html, css, classMap } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderStatus() {
-  const pkg = this.context.store.pupContext
+  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const { statusId, statusLabel } = pkg.computed
+  const isLoadingStatus = ["installing"].includes(statusId);
   const styles = css`
     .status-label {
       font-size: 2em;


### PR DESCRIPTION
This PR primary
- renders the pup status and its available actions according to `installation` and `status`.

This PR also 
- changes enable/disabling from being a button  to a toggle.
- invokes an API request on toggle change
- allows actions to have an optional timeout with an onTimeout callback

Todo (subsequent PRs)
- Uninstall button
- Uninstalled state
- I suspect small changes will be needed when integrating with the API when ready.

![Screenshot 2024-08-21 at 3 28 55 PM](https://github.com/user-attachments/assets/b2133f5c-bb9b-4130-adca-c4e3037c2187)
![Screenshot 2024-08-21 at 3 29 00 PM](https://github.com/user-attachments/assets/bf7900cd-a5fb-48f2-bac4-9fab155d3c87)
![Screenshot 2024-08-21 at 3 29 04 PM](https://github.com/user-attachments/assets/3296494c-fa0d-4f03-869e-4876807e7f97)
![Screenshot 2024-08-21 at 3 29 10 PM](https://github.com/user-attachments/assets/7a139bee-87e6-4b7b-b990-ef07eec1f7c1)

