### PR TITLE
Uninstall (not purge)

### DIFF
--- a/src/api/action/action.js
+++ b/src/api/action/action.js
@@ -3,27 +3,36 @@ import { store } from '/state/store.js'
 
 import { 
   startMock,
+  stopMock,
   installMock,
+  uninstallMock,
 } from './action.mocks.js'
 
 const client = new ApiClient('http://localhost:3000', store.networkContext)
 
-export async function stopPup(pupId, body) {
-  return client.post(`/action/${pupId}/stop`, body, { mock: startMock });
+export async function installPup(pupId, body) {
+  return client.post(`/action/${pupId}/install`, body, { mock: installMock });
+}
+
+export async function uninstallPup(pupId, body) {
+  return client.post(`/action/${pupId}/uninstall`, body, { mock: uninstallMock });
 }
 
 export async function startPup(pupId, body) {
-  return client.post(`/action/${pupId}/start`, body, { mock: startMock });
+  return client.post(`/action/${pupId}/enable`, body, { mock: startMock });
 }
 
-export async function installPup(pupId, body) {
-  return client.post(`/action/${pupId}/install`, body, { mock: installMock });
+export async function stopPup(pupId, body) {
+  return client.post(`/action/${pupId}/disable`, body, { mock: stopMock });
 }
 
 export function pickAndPerformPupAction(pupId, action) {
   switch(action) {
     case 'install':
       return installPup(pupId);
+      break;
+    case 'uninstall':
+      return uninstallPup(pupId);
       break;
     case 'start':
       return startPup(pupId);

--- a/src/api/action/action.mocks.js
+++ b/src/api/action/action.mocks.js
@@ -5,7 +5,14 @@ const postResponse = {
 }
 
 export const startMock = {
-  name: '/action/:pup/start',
+  name: '/action/:pup/enable',
+  method: 'post',
+  group: 'pup actions',
+  res: postResponse
+}
+
+export const stopMock = {
+  name: '/action/:pup/disable',
   method: 'post',
   group: 'pup actions',
   res: postResponse
@@ -13,6 +20,13 @@ export const startMock = {
 
 export const installMock = {
   name: '/action/:pup/install',
+  method: 'post',
+  group: 'pup actions',
+  res: postResponse
+}
+
+export const uninstallMock = {
+  name: '/action/:pup/uninstall',
   method: 'post',
   group: 'pup actions',
   res: postResponse

--- a/src/api/bootstrap/bootstrap.mocks.js
+++ b/src/api/bootstrap/bootstrap.mocks.js
@@ -21,7 +21,7 @@ function generateStates(manifests) {
         stats: generateRandomStats(),
         config: generateConfigOptions(p.command.config),
         installation: "ready",
-        enabled: !!['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar'].includes(p.package),
+        enabled: !!['Core', 'Dogeboxd', 'Map', 'Identity', 'Tipjar', 'ShibeShop'].includes(p.package),
         needs_deps: false,
         needs_config: false,
       };

--- a/src/api/mocks.js
+++ b/src/api/mocks.js
@@ -1,4 +1,4 @@
-import { startMock, installMock } from "./action/action.mocks.js"
+import { startMock, stopMock, installMock, uninstallMock } from "./action/action.mocks.js"
 import { mock as bootstrapMocks } from "./bootstrap/bootstrap.mocks.js"
 import { postResponse as pupConfigPost, getResponse as pupConfigGetById, getAllResponse as pupConfigGetAll } from "./config/config.mocks.js";
 import { getResponse as dkmGet } from "./keys/get-keylist.mocks.js";
@@ -12,8 +12,10 @@ import { getResponse as apModeFacts } from "./setup/get-bootstrap.mocks.js";
 
 export const mocks = [
   bootstrapMocks,
-  startMock,
   installMock,
+  uninstallMock,
+  startMock,
+  stopMock,
   pupConfigGetAll,
   pupConfigGetById,
   pupConfigPost,

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -393,6 +393,14 @@ function determineStatusId(state) {
     needs_config: state?.needs_config
   }
 
+  if (installation === "uninstalling") {
+    return { id: "uninstalling", label: "Uninstalling" }
+  }
+
+  if (installation === "uninstalled") {
+    return { id: "uninstalled", label: "Uninstalled" }
+  }
+
   if (flags.needs_deps) {
     return { id: "needs_deps", label: "Missing Dependencies" };
   }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -163,7 +163,7 @@ class PupPage extends LitElement {
     const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
     const { installationId, statusId, statusLabel } = pkg.computed
     const hasChecks = (pkg?.manifest?.checks || []).length > 0;
-    const isLoadingStatus =  ["starting", "stopping", "crashing"].includes(statusId);
+    const isLoadingStatus =  ["starting", "stopping", "uninstalling"].includes(statusId);
 
     const renderHealthChecks = () => {
       return this.checks.map(
@@ -333,6 +333,7 @@ class PupPage extends LitElement {
       --indicator-color: #999;
       &.starting { --indicator-color: var(--sl-color-primary-600); }
       &.stopping { --indicator-color: var(--sl-color-danger-600); }
+      &.uninstalling { --indicator-color: var(--sl-color-danger-600); }
     }
   `;
 }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -5,6 +5,7 @@ import {
   nothing,
   choose,
   unsafeHTML,
+  classMap,
 } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import "/components/common/action-row/action-row.js";
 import "/components/common/dynamic-form/dynamic-form.js";
@@ -164,11 +165,12 @@ class PupPage extends LitElement {
     const { installationId, statusId, statusLabel } = pkg.computed
     const hasChecks = (pkg?.manifest?.checks || []).length > 0;
     const isLoadingStatus =  ["starting", "stopping", "uninstalling"].includes(statusId);
+    const disableActions = installationId === "uninstalled"
 
     const renderHealthChecks = () => {
       return this.checks.map(
         (check) => html`
-          <health-check status=${check.status} .check=${check} ?disabled=${!this.pupEnabled}></health-check>
+          <health-check status=${check.status} .check=${check} ?disabled=${!this.pupEnabled || disableActions}></health-check>
         `,
       );
     };
@@ -182,24 +184,24 @@ class PupPage extends LitElement {
     }
 
     const renderMenu = () => html`
-      <action-row prefix="power" name="state" label="Enabled">
+      <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
         Enable or disable this Pup
-        <sl-switch slot="suffix" ?checked=${pkg.state.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight || installationId === "unready"}></sl-switch>
+        <sl-switch slot="suffix" ?checked=${!disableActions && pkg.state.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight || installationId !== "ready"}></sl-switch>
       </action-row>
 
-      <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick}>
+      <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
         Customize ${pkg.manifest.package}
       </action-row>
 
-      <!--action-row prefix="archive-fill" name="properties" label="Properties" .trigger=${this.handleMenuClick}>
+      <!--action-row prefix="archive-fill" name="properties" label="Properties" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
         Ea sint dolor commodo.
       </action-row-->
 
-      <!--action-row prefix="lightning-charge" name="actions" label="Actions" .trigger=${this.handleMenuClick}>
+      <!--action-row prefix="lightning-charge" name="actions" label="Actions" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
         Ea sint dolor commodo.
       </action-row-->
 
-      <action-row prefix="display" name="logs" label="Logs" href="${window.location.pathname}/logs">
+      <action-row prefix="display" name="logs" label="Logs" href="${window.location.pathname}/logs" ?disabled=${disableActions}>
         Unfiltered logs
       </action-row>
     `;
@@ -215,10 +217,15 @@ class PupPage extends LitElement {
     `
 
     const renderCareful = () => html`
-      <action-row prefix="trash3-fill" name="uninstall" label="Uninstall" .trigger=${this.handleMenuClick}>
+      <action-row prefix="trash3-fill" name="uninstall" label="Uninstall" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
         Remove this pup from your system
       </action-row>
     `
+
+    const sectionTitleClasses = classMap({
+      "section-title": true,
+      "disabled": disableActions
+    })
 
     return html`
       <div id="PageWrapper" class="wrapper">
@@ -230,7 +237,7 @@ class PupPage extends LitElement {
         </section>
 
         <section>
-          <div class="section-title">
+          <div class=${sectionTitleClasses}>
             <h3>Menu</h3>
           </div>
           <div class="list-wrap">${renderMenu()}</div>
@@ -238,7 +245,7 @@ class PupPage extends LitElement {
 
         ${hasChecks ? html`
         <section>
-          <div class="section-title">
+          <div class=${sectionTitleClasses}>
             <h3>Health checks</h3>
           </div>
           <div class="list-wrap">${renderHealthChecks()}</div>
@@ -307,6 +314,10 @@ class PupPage extends LitElement {
 
     section .section-title {
       margin-bottom: 0em;
+    }
+
+    section .section-title.disabled {
+      color: var(--sl-color-neutral-400);
     }
 
     section .section-title h3 {

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -13,7 +13,12 @@ export function openDeps() {
 export function renderActions() {
   const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
   const { installationId, statusId, statusLabel } = pkg.computed
-  const hasButtons =  ["needs_deps", "needs_config"].includes(statusId) || pkg.manifest.gui;
+
+  const hasButtons =
+    ["needs_deps", "needs_config"].includes(statusId)
+    || ["uninstalled"].includes(installationId)
+    || pkg.manifest.gui;
+
   const styles = css`
     .action-wrap {
       display: flex;
@@ -47,6 +52,12 @@ export function renderActions() {
       ${statusId === 'needs_deps' ? html`
         <sl-button variant="warning" size="large" name="deps" label="dependencies" @click=${this.openDeps}>
           View List
+        </sl-button>
+      ` : nothing }
+
+      ${installationId === 'uninstalled' ? html`
+        <sl-button variant="warning" size="large" href="${pkg.computed.url.store}">
+          Such Install
         </sl-button>
       ` : nothing }
 

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -6,13 +6,28 @@ import {
 
 export function renderDialog() {
   const pkg = this.pkgController.getPup(this.pupId);
+  const { statusId } = pkg.computed
   const readmeEl = html`${unsafeHTML(pkg?.manifest?.docs?.about)}`;
   const depsEl = pkg.manifest.deps.pups.length > 0 
     ? pkg.manifest.deps.pups.map((dep) => html`
       <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
         ${dep.condition}
       </action-row>`)
-    : html`<div style="padding: 1em; text-align: center;"> Such empty. This pup depends on no other.</div>`
+    : html`<div style="padding: 1em; text-align: center;"> Such empty. This pup depends on no other.</div>
+  `;
+
+  const preventUninstallEl = html`
+    <p>Cannot uninstall a running Pup.<br/>Please disable ${pkg.manifest.package } and try again.</p>
+    <sl-button slot="footer" variant="primary" @click=${this.clearDialog}>Dismiss</sl-button>
+    <style>p:first-of-type { margin-top: 0px; }</style>
+  `
+
+  const uninstallEl = html`
+    <p>Are you sure you want to uninstall ${pkg.manifest.package  }?</p>
+    <sl-input placeholder="Type '${pkg.manifest.package}' to confirm" @sl-input=${(e) => this._confirmedName = e.target.value }></sl-input>
+    <sl-button slot="footer" variant="danger" @click=${this.handleUninstall} ?loading=${this.inflight} ?disabled=${this.inflight || this._confirmedName !== pkg.manifest.package}>Uninstall</sl-button>
+    <style>p:first-of-type { margin-top: 0px; }</style>
+  `;
 
   const configEl = html`
     <dynamic-form
@@ -26,6 +41,8 @@ export function renderDialog() {
     </dynamic-form>
   `;
 
+  const isStopped = !this.pupEnabled && statusId !== "running";
+
   return html`
     ${choose(
       this.open_dialog,
@@ -33,6 +50,7 @@ export function renderDialog() {
         ["readme", () => readmeEl],
         ["deps", () => depsEl],
         ["configure", () => configEl],
+        ["uninstall", () => isStopped ? uninstallEl : preventUninstallEl],
       ],
       () => html`<span>View not provided: ${this.open_dialog}</span>`,
     )}

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -20,11 +20,15 @@ export function renderStatus() {
 
       &.needs_deps { color: var(--sl-color-amber-600); }
       &.needs_config { color: var(--sl-color-amber-600); }
+
       &.starting { color: var(--sl-color-primary-600); }
       &.stopping { color: var(--sl-color-danger-600); }
-      &.stopped { color: var(--color-neutral); }
       &.running { color: var(--sl-color-success-600); }
+      &.stopped { color: var(--color-neutral); }
+
       &.broken { color: var(--sl-color-danger-600);}
+      &.uninstalling { color: var(--sl-color-danger-600); }
+      &.uninstalled { color: var(--color-neutral); }
     }
   `
 

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -26,7 +26,7 @@ export function renderActions() {
   return html`
     <div class="action-wrap">
 
-      ${installationId === "not_installed" ? html`
+      ${["not_installed", "uninstalled"].includes(installationId) ? html`
         <sl-button variant="warning" size="large"
           @click=${this.handleInstall}
           ?disabled=${this.inflight}

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -4,10 +4,17 @@ export function renderStatus() {
   const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
   const { installationId, installationLabel } = pkg.computed
   const isLoadingStatus = ["installing"].includes(installationId);
+  const normalisedLabel = () => {
+    if (["not_installed", "uninstalled"].includes(installationId)) {
+      return "Not installed"
+    } else {
+      return installationLabel
+    }
+  }
 
   return html`
     <div class="section-title">
-      <h3 class="installation-label ${installationId}">${installationLabel}</h3>
+      <h3 class="installation-label ${installationId}">${normalisedLabel()}</h3>
     </div>
     <div>
       <span class="status-label">${pkg.manifest.package}</span>


### PR DESCRIPTION
This PR adds an uninstall menu item under a "be careful" section of the pup page.

When clicked, one of two prompts display:

- If the pup is running, the "cannot uninstall a running pup" prompt is shown.
- If the pup is not running, the "are you sure" prompt is shown.

A user must type in the name of the package (also shown on screen) to confirm.

On click, a pup action request of type "uninstall" is made.  The pup page will then flick into its uninstalling state once dogeboxd emits the relevant pup status message.

Todo (within this PR)
- [X] Uninstall menu item
- [X] Uninstall dialogs
- [X] Prevent uninstallation of running pup
- [X] Ask user to confirm intent
- [X] Submit pup action request (post to server)
- [ ] Ensure "Uninstalling" label has correct colour 

![image](https://github.com/user-attachments/assets/26d353ef-054d-403d-bf10-4d31a98bae1d)
