### PR TITLE
Login: Integrate to backend actuals

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -37,7 +37,7 @@ export default class ApiClient {
     const headers = { 'Content-Type': 'application/json', ...config.headers };
 
     if (this.networkContext.token) {
-      headers.Authorization = this.networkContext.token
+      headers.Authorization = `Bearer ${this.networkContext.token}`
     }
 
     let response, data
@@ -52,8 +52,17 @@ export default class ApiClient {
       throw new Error(`Resource not found: ${url}`);
     }
 
+    if (response.status === 403) {
+      return { success: false, error: true, status: 403 }
+    }
+
+    if (response.status === 401) {
+      return window.location.href = window.location.origin + "/logout"
+    }
+
     if (!response.ok) {
-      throw new Error('Fetching returned an unsuccessful response', { ok, status: repsonse.status });
+      console.warn('Unsuccessful respose', { status: response.status })
+      throw new Error('Fetching returned an unsuccessful response');
     }
 
     try {

--- a/src/api/login/login.js
+++ b/src/api/login/login.js
@@ -8,9 +8,12 @@ import {
 const client = new ApiClient('http://localhost:3000', store.networkContext)
 
 export async function postLogin(body) {
-  const res = await client.post(`/auth/login`, body, { mock: postResponse });
+  const res = await client.post(`/authenticate`, body, { mock: postResponse });
   if (res && res.token) {
     store.updateState({ networkContext: { token: res.token }})
+  }
+  if (res.error & res.status === 403) {
+    return { error: "CHECK-CREDS" }
   }
   return res
 }

--- a/src/api/login/login.mocks.js
+++ b/src/api/login/login.mocks.js
@@ -1,5 +1,5 @@
 export const postResponse = {
-  name: "/login",
+  name: "/authenticate",
   group: "auth",
   method: "post",
   res: {

--- a/src/app.js
+++ b/src/app.js
@@ -100,6 +100,9 @@ class DPanelApp extends LitElement {
     // this.outletWrapper = this.shadowRoot.querySelector("#OutletWrapper")
     this.router = new Router(outlet);
     this.router.setRoutes(routes)
+    this.router.addHook(
+      () => store.updateState({ appContext: { menuVisible: false }})
+    )
   }
 
   _handleResize() {
@@ -149,6 +152,7 @@ class DPanelApp extends LitElement {
     const taskName = this.context.store.promptContext.name;
     const showChrome = !CURPATH.startsWith("/login");
     const mainClasses = classMap({
+      fullscreen: !showChrome,
       backward: this.context.store.appContext.navigationDirection === "backward",
       opaque: showSystemPrompt,
     });

--- a/src/components/layouts/standard/styles/main.styles.js
+++ b/src/components/layouts/standard/styles/main.styles.js
@@ -29,6 +29,11 @@ export const mainStyles = css`
       height: 100%;
       width: calc(100% - var(--page-margin-left));
     }
+
+    &.fullscreen {
+      margin-left: 0;
+      width: 100%;
+    }
   }
 
   #Main.opaque {

--- a/src/components/views/action-login/index.js
+++ b/src/components/views/action-login/index.js
@@ -135,7 +135,6 @@ class LoginView extends LitElement {
   handleFault = (loginFault) => {
     this._server_fault = true;
     console.warn(loginFault);
-    // window.alert("boo. something went wrong");
   };
 
   handleError(loginResponseError) {

--- a/src/components/views/action-login/index.js
+++ b/src/components/views/action-login/index.js
@@ -101,7 +101,6 @@ class LoginView extends LitElement {
     // TODO
     // data.password = await hash(data.password);
     const loginResponse = await postLogin(data).catch(this.handleFault);
-
     if (!loginResponse) {
       dynamicFormInstance.retainChanges(); // stops spinner
       return;
@@ -136,7 +135,7 @@ class LoginView extends LitElement {
   handleFault = (loginFault) => {
     this._server_fault = true;
     console.warn(loginFault);
-    window.alert("boo. something went wrong");
+    // window.alert("boo. something went wrong");
   };
 
   handleError(loginResponseError) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
+import "./page-login/index.js";
 import "./page-home/index.js";
 import "./page-iframe/index.js";
 import "./page-pup-library/index.js";

--- a/src/pages/page-login/index.js
+++ b/src/pages/page-login/index.js
@@ -1,0 +1,13 @@
+import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+import "/components/views/action-login/index.js";
+
+class PageLogin extends LitElement {
+
+  render() {
+    return html`
+      <x-action-login></x-action-login>
+    `;
+  }
+}
+
+customElements.define('x-page-login', PageLogin);

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -8,7 +8,7 @@ export function renderDialog() {
   const pkg = this.pkgController.getPup(this.pupId);
   const { statusId } = pkg.computed
   const readmeEl = html`${unsafeHTML(pkg?.manifest?.docs?.about)}`;
-  const depsEl = pkg.manifest.deps.pups.length > 0 
+  const depsEl = pkg.manifest?.deps?.pups?.length > 0 
     ? pkg.manifest.deps.pups.map((dep) => html`
       <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
         ${dep.condition}

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -1,4 +1,4 @@
-import { loadPup, asPage } from "./middleware.js"
+import { loadPup, asPage, performLogout } from "./middleware.js"
 
 export const routes = [
   {
@@ -6,6 +6,14 @@ export const routes = [
     component: "x-page-home",
     pageTitle: "Home",
     before: [asPage]
+  },
+  {
+    path: "/logout",
+    before: [performLogout]
+  },
+  {
+    path: "/login",
+    component: "x-action-login",
   },
   {
     path: "/stats",

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -1,6 +1,7 @@
 export class Router {
   constructor(outlet, options = {}) {
     this.routes = [];
+    this.hooks = [];
     this.outlet = outlet;
     this.transitionDuration = options.transitionDuration || 300;
     this.currentTransition = null;
@@ -27,7 +28,7 @@ export class Router {
 
   addRoute(path, component, route) {
     const componentClass = customElements.get(component);
-    if (!componentClass) {
+    if (component && !componentClass) {
       console.error(`Component ${component} not found.`);
       return;
     }
@@ -38,6 +39,10 @@ export class Router {
       regex,
       componentClass,
     });
+  }
+
+  addHook(fn) {
+    this.hooks.push(fn);
   }
 
   go(path, replace = false) {
@@ -86,6 +91,10 @@ export class Router {
           for (const func of route.after) {
             await func(context, commands);
           }
+        }
+
+        for (const func of this.hooks) {
+          const commandResult = await func(context, commands);
         }
       } catch (error) {
         if (error.message === 'Redirection') {


### PR DESCRIPTION
**This PR:**
- Adjusts the login implementation to fit the backend actuals
- Supplies Bearer Token on all requests
- Redirects users to /logout on 403

**In addition:**
- Router now can have hooks added
- 1 hook added that closes the menu after all navigation
- Adjusted styles so Login UI is correctly centered;
- Routes can now be configured without a 'component' (such as /logout, which only runs a middleware)