### PR TITLE
[Cutover] Store/Library API and Data Structure

### DIFF
--- a/src/api/bootstrap/bootstrap.js
+++ b/src/api/bootstrap/bootstrap.js
@@ -1,9 +1,14 @@
 import ApiClient from '/api/client.js';
 import { store } from '/state/store.js'
 import { mock } from './bootstrap.mocks.js'
+import { mockV2 } from './bootstrap.mocks.v2.js'
 
 const client = new ApiClient('http://localhost:3000', store.networkContext)
 
 export async function getBootstrap() {
-  return client.get('/system/bootstrap', { mock });
+  return client.get('/setup/bootstrap', { mock });
+}
+
+export async function getBootstrapV2() {
+  return client.get('/system/bootstrap', { mock: mockV2 })
 }

--- a/src/api/bootstrap/bootstrap.mocks.js
+++ b/src/api/bootstrap/bootstrap.mocks.js
@@ -97,7 +97,7 @@ function generateRandomStats() {
 };
 
 export const mock = {
-  name: '/system/bootstrap',
+  name: '/system/bootstrap (deprecating)',
   method: 'get',
   group: 'system',
   res: generateBootstrap

--- a/src/api/bootstrap/bootstrap.mocks.v2.js
+++ b/src/api/bootstrap/bootstrap.mocks.v2.js
@@ -1,0 +1,47 @@
+import { generateManifestsV2 } from "../manifest/manifest.mocks.v2.js";
+import { generateStatesV2 } from "../states/states.mocks.js"
+
+export const mockV2 = {
+  name: '/system/bootstrap',
+  method: 'get',
+  group: 'system',
+  res: generateBootstrapV2
+}
+
+function generateBootstrapV2() {
+  const manifests = generateManifestsV2(['Dogeboxd', 'Core', 'GigaWallet']);
+  const states = generateStatesV2(manifests);
+  const setupFacts = generateSetupFacts();
+  const stats = generateRandomStatsV2(states);
+
+  return {
+    manifests,
+    setupFacts,
+    states,
+    stats,
+  }
+}
+
+function generateSetupFacts() {
+  return { hasCompletedInitialConfiguration: true, hasConfiguredNetwork: true, hasGeneratedKey: true };
+}
+
+function generateRandomStatsV2(states) {
+  return Object.keys(states).reduce((stats, stateId) => {
+    stats[stateId] = {
+      id: stateId,
+      status: Math.random() > 0.5 ? "running" : "stopped",
+      status_cpu: generateRandomValues(),
+      status_disk: generateRandomValues(),
+      status_mem: generateRandomValues(),
+    };
+    return stats;
+  }, {});
+}
+
+function generateRandomValues() {
+  return {
+    Head: Math.floor(Math.random() * 32),
+    Values: Array.from({ length: 32 }, () => Math.floor(Math.random() * 100)),
+  };
+}

--- a/src/api/manifest/manifest.mocks.v2.js
+++ b/src/api/manifest/manifest.mocks.v2.js
@@ -1,0 +1,123 @@
+export function generateManifestsV2(input) {
+  const randomChoice = (choices) => choices[Math.floor(Math.random() * choices.length)];
+  const randomSemver = () => `${Math.floor(Math.random() * 10)}.${Math.floor(Math.random() * 10)}.${Math.floor(Math.random() * 10)}`;
+
+  const fieldLabels = {
+    number: 'Number',
+    text: 'Text',
+    select: 'Select',
+    toggle: 'Toggle',
+    checkbox: 'Checkbox',
+    radioButton: 'RadioButton',
+    radio: 'Radio',
+    range: 'Range',
+    date: 'Date',
+    // rating: 'Rating',
+    color: 'Color',
+    textarea: 'Textarea',
+  };
+
+  const generateRandomConfig = () => {
+    const sectionNames = ['Identity', 'Connection'];
+    const fields = Object.keys(fieldLabels);
+    const options = {
+      select: [
+        { label: 'Blue', value: 'blue' },
+        { label: 'Green', value: 'green' },
+        { label: 'Purple', value: 'purple' },
+      ],
+      radio: [
+        { label: 'Burger', value: 'burger' },
+        { label: 'Nuggets', value: 'nuggets' },
+        { label: 'Fries', value: 'fries' },
+      ],
+      radioButton: [
+        { label: 'Orange', value: 'orange' },
+        { label: 'Lemon', value: 'lemon' },
+        { label: 'Lime', value: 'lime' },
+      ]
+    };
+
+    // We have 12 field types.
+    // We're going to generate a form that has 2 sections
+    // with half the fields in the first section, half in the other.
+    const halfFieldCount = Math.ceil(fields.length / 2);
+
+    return {
+      sections: sectionNames.map((sectionName, sectionIndex) => {
+        const sliceStartIndex = sectionIndex * halfFieldCount;
+        const sliceEndIndex = sliceStartIndex + halfFieldCount;
+        return {
+          name: sectionName,
+          fields: fields.slice(sliceStartIndex, sliceEndIndex)
+            .map((field, fieldIndex) => ({
+            label: fieldLabels[field],
+            name: `${field}_${sectionIndex}_${fieldIndex}`,
+            type: field,
+            ...(field === 'checkbox' || field === 'toggle' || field === 'rating' ? { required: false } : { required: randomChoice([true, true]) }),
+            ...(field === 'select' || field === 'radio' || field === 'radioButton' ? { options: [...options[field]] } : {}),
+            ...(field === 'range' ? { min: 1, max: 69, step: 1 } : {})
+          }))
+          }
+      })
+    };
+  };
+
+  const names = Array.isArray(input) ? input : Array.from({ length: input }, (_, index) => `Package_${index + 1}`);
+
+  const produce = (array) => array.map(name => ({
+    config: generateRandomConfig(),
+    container: {
+      build: {
+        nixFile: `${name.toLowerCase()}.nix`,
+        nixFileSha256: "",
+      },
+      exposes: [
+        {
+          port: 80,
+          trafficType: "http",
+          type: "admin",
+        },
+        {
+          port: 81,
+          trafficType: "http",
+          type: "admin",
+        },
+      ],
+      services: [
+        {
+          command: {
+            cwd: "/bin/",
+            env: {},
+            exec: `/bin/start-${name.toLowerCase()}1`,
+          },
+          name: `${name.toLowerCase()}1`,
+        },
+        {
+          command: {
+            cwd: "/bin/",
+            env: {},
+            exec: `/bin/start-${name.toLowerCase()}2`,
+          },
+          name: `${name.toLowerCase()}2`,
+        },
+      ],
+    },
+    dependencies: [],
+    manifestVersion: 1,
+    meta: {
+      logoPath: "",
+      name: name,
+      version: randomSemver(),
+    },
+    permissionGroups: [],
+  }));
+
+  // 'Mock a hardcoded set'
+  if (!input) {
+    return produce(['Core', 'Identity', 'GigaWallet', 'ShibeShop', 'Map', 'Tipjar'])
+  };
+
+  // Mock a dynamic set that considers the input.
+  return produce(names)
+}

--- a/src/api/mocks.js
+++ b/src/api/mocks.js
@@ -1,5 +1,7 @@
 import { startMock, stopMock, installMock, uninstallMock } from "./action/action.mocks.js"
 import { mock as bootstrapMocks } from "./bootstrap/bootstrap.mocks.js"
+import { storeListingMock } from "./sources/sources.mocks.js"
+import { mockV2 as bootstrapV2Mocks } from "./bootstrap/bootstrap.mocks.v2.js"
 import { postResponse as pupConfigPost, getResponse as pupConfigGetById, getAllResponse as pupConfigGetAll } from "./config/config.mocks.js";
 import { getResponse as dkmGet } from "./keys/get-keylist.mocks.js";
 import { postResponse as dkmCreate } from "./keys/create-key.mocks.js";
@@ -11,6 +13,8 @@ import { getResponse as checkReflector } from "./reflector/get-ip.mocks.js";
 import { getResponse as apModeFacts } from "./setup/get-bootstrap.mocks.js";
 
 export const mocks = [
+  storeListingMock,
+  bootstrapV2Mocks,
   bootstrapMocks,
   installMock,
   uninstallMock,

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -1,0 +1,12 @@
+import ApiClient from '/api/client.js';
+import { store } from '/state/store.js'
+
+import { 
+  storeListingMock
+} from './sources.mocks.js'
+
+const client = new ApiClient('http://localhost:3000', store.networkContext)
+
+export async function getStoreListing() {
+  return client.get('/sources/store', { mock: storeListingMock });
+}

--- a/src/api/sources/sources.mocks.js
+++ b/src/api/sources/sources.mocks.js
@@ -17,10 +17,12 @@ function _generateStoreListingResponse(sources) {
       pups: {}
     };
 
-    pups.forEach(pupName => {
+    pups.forEach((pupName, i) => {
       response[sourceName].pups[pupName.toLowerCase()] = {
         installedVersion: "1.0.0",
-        isInstalled: false,
+        installedId: `mock-pup-id-${i}`, // TODO
+        latestVersion: "1.0.3",
+        isInstalled: true,
         versions: {
           "0.0.1": generateVersionData("0.0.1", pupName),
           "1.0.0": generateVersionData("1.0.0", pupName),

--- a/src/api/sources/sources.mocks.js
+++ b/src/api/sources/sources.mocks.js
@@ -1,0 +1,211 @@
+export const storeListingMock = {
+  name: '/sources/store',
+  method: 'get',
+  group: 'sources',
+  res: () => _generateStoreListingResponse({
+    fdn: ["ShibeShop", "Identity"],
+    sourdoge: ["SuchBake", "SoBread"]
+  })
+}
+
+function _generateStoreListingResponse(sources) {
+  const response = {};
+
+  for (const [sourceName, pups] of Object.entries(sources)) {
+    response[sourceName] = {
+      lastUpdated: new Date().toISOString(),
+      pups: {}
+    };
+
+    pups.forEach(pupName => {
+      response[sourceName].pups[pupName.toLowerCase()] = {
+        installedVersion: "1.0.0",
+        isInstalled: false,
+        versions: {
+          "0.0.1": generateVersionData("0.0.1", pupName),
+          "1.0.0": generateVersionData("1.0.0", pupName),
+          "1.0.3": generateVersionData("1.0.3", pupName)
+        }
+      };
+    });
+  }
+
+  return response;
+}
+
+function generateVersionData(version, pupName) {
+  return {
+    config: { sections: null },
+    container: {
+      build: { nixFile: "pup.nix", nixFileSha256: "" },
+      exposes: [{ port: 8080, trafficType: "http", type: "admin", } ],
+      services: [{ command: { cwd: "", env: null, exec: `/bin/${pupName.toLowerCase()}`, }, name: "main", }],
+    },
+    dependencies: [],
+    manifestVersion: 1,
+    meta: {
+      logoPath: "",
+      name: pupName,
+      version: version,
+      descShort: "Such package, much use.",
+      descLong: "Anim qui in sunt in ea dolore voluptate cillum excepteur consectetur pariatur tempor adipisicing cupidatat dolor ullamco ullamco quis sed ullamco amet voluptate magna labore dolor elit nisi magna est ut qui nulla ex esse duis nostrud occaecat amet ea fugiat minim sint ad in sed laborum fugiat aliqua excepteur sit eiusmod do deserunt ut nisi enim dolor esse reprehenderit consectetur mollit irure do in aliquip esse aliqua reprehenderit deserunt excepteur enim dolor exercitation qui occaecat non culpa voluptate anim cupidatat commodo amet dolor reprehenderit velit reprehenderit officia ea exercitation labore cillum mollit irure nostrud pariatur cupidatat deserunt laborum esse incididunt fugiat reprehenderit consectetur adipisicing mollit non in labore sit eiusmod pariatur elit mollit velit cupidatat eu consectetur amet eiusmod cillum occaecat consectetur culpa dolore consequat sunt voluptate cillum magna nulla labore esse ut dolor laboris enim veniam sit excepteur deserunt duis cupidatat minim culpa aliqua dolor ad velit pariatur aliquip proident eu non proident enim voluptate officia commodo occaecat sit commodo voluptate consequat magna laboris et in elit veniam consequat excepteur sit qui officia ut deserunt et cillum exercitation enim elit consectetur non anim do aliquip nostrud incididunt veniam veniam sit veniam in aliqua laboris consectetur irure in veniam occaecat est consectetur nisi non est culpa dolor aliqua velit reprehenderit mollit exercitation in magna dolor irure.",
+    },
+    permissionGroups: [],
+  };
+}
+
+function generateStoreListingResponse() {
+  return {
+    "mock-source-fdn": {
+      lastUpdated: "2024-09-04T10:23:14+10:00",
+      pups: {
+        "mock-test-pup": {
+          installedVersion: "",
+          isInstalled: false,
+          versions: {
+            "": {
+              config: {
+                sections: null,
+              },
+              container: {
+                build: {
+                  nixFile: "",
+                  nixFileSha256: "",
+                },
+                exposes: null,
+                services: null,
+              },
+              dependencies: null,
+              manifestVersion: 0,
+              meta: {
+                logoPath: "",
+                name: "",
+                version: "",
+              },
+              permissionGroups: null,
+            },
+            "0.0.3-dev": {
+              config: {
+                sections: null,
+              },
+              container: {
+                build: {
+                  nixFile: "",
+                  nixFileSha256: "",
+                },
+                exposes: null,
+                services: null,
+              },
+              dependencies: null,
+              manifestVersion: 0,
+              meta: {
+                logoPath: "",
+                name: "",
+                version: "0.0.3-dev",
+              },
+              permissionGroups: null,
+            },
+            "0.0.4": {
+              config: {
+                sections: null,
+              },
+              container: {
+                build: {
+                  nixFile: "pup.nix",
+                  nixFileSha256: "",
+                },
+                exposes: [
+                  {
+                    port: 80,
+                    trafficType: "http",
+                    type: "admin",
+                  },
+                  {
+                    port: 81,
+                    trafficType: "http",
+                    type: "admin",
+                  },
+                ],
+                services: [
+                  {
+                    command: {
+                      cwd: "/bin/",
+                      env: {},
+                      exec: "/bin/start-server1",
+                    },
+                    name: "server1",
+                  },
+                  {
+                    command: {
+                      cwd: "/bin/",
+                      env: {},
+                      exec: "/bin/start-server2",
+                    },
+                    name: "server2",
+                  },
+                ],
+              },
+              dependencies: [],
+              manifestVersion: 1,
+              meta: {
+                logoPath: "",
+                name: "s1w test pup",
+                version: "0.0.4",
+              },
+              permissionGroups: [],
+            },
+            "0.0.5": {
+              config: {
+                sections: null,
+              },
+              container: {
+                build: {
+                  nixFile: "pup.nix",
+                  nixFileSha256: "",
+                },
+                exposes: [
+                  {
+                    port: 8080,
+                    trafficType: "http",
+                    type: "admin",
+                  },
+                  {
+                    port: 8081,
+                    trafficType: "http",
+                    type: "admin",
+                  },
+                ],
+                services: [
+                  {
+                    command: {
+                      cwd: "",
+                      env: null,
+                      exec: "/bin/server1",
+                    },
+                    name: "server1",
+                  },
+                  {
+                    command: {
+                      cwd: "",
+                      env: null,
+                      exec: "/bin/server2",
+                    },
+                    name: "server2",
+                  },
+                ],
+              },
+              dependencies: [],
+              manifestVersion: 1,
+              meta: {
+                logoPath: "",
+                name: "s1w test pup",
+                version: "0.0.5",
+              },
+              permissionGroups: [],
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/api/states/states.mocks.js
+++ b/src/api/states/states.mocks.js
@@ -1,0 +1,161 @@
+export function generateStatesV2(manifests) {
+  return manifests.reduce((out, manifest, i) => {
+    const id = `mock-pup-id-${i+1}`;
+    out[id] = {
+      config: generateConfigValues(manifest.config),
+      enabled: true,
+      id: id,
+      status: "running",
+      installation: "ready",
+      ip: generateRandomIp(),
+      manifest: manifest,
+      needsConf: false,
+      needsDeps: false,
+      source: {
+        location: generateSourceLocation(manifest),
+        name: generateSourceName(manifest),
+        type: "git",
+      },
+      version: manifest.meta.version,
+    };
+    return out;
+  }, {});
+}
+
+function generateRandomIp() {
+  return `10.0.0.${Math.floor(Math.random() * 255)}`;
+}
+
+function generateSourceLocation(manifest) {
+  return `https://github.com/flibble/${manifest.meta.name.toLowerCase().replace(/\s+/g, '-')}.git`;
+}
+
+function generateSourceName(manifest) {
+  return manifest.meta.name.toLowerCase().replace(/\s+/g, '');
+}
+
+function generateConfigValues(config) {
+  return config.sections.reduce((result, section) => {
+    section.fields.forEach(field => {
+      result[field.name] = generateValue(field.name);
+    });
+    return result;
+  }, {});
+}
+
+function generateValue(fieldName) {
+  if (fieldName.includes('text_')) {
+    return 'Such wow';
+  }
+
+  if (fieldName.includes('textarea_')) {
+    return 'Excepteur magna proident sed fugiat officia eiusmod adipisicing ad in id magna fugiat elit.';
+  }
+
+  if (fieldName.includes('number_')) {
+    return Math.round(69 * Math.random()).toString();
+  }
+
+  if (fieldName.includes('checkbox_')) {
+    return true;
+  }
+
+  if (fieldName.includes('toggle_')) {
+    return false;
+  }
+
+  if (fieldName.includes('select_')) {
+    return "purple";
+  }
+
+  if (fieldName.includes('rating_')) {
+    return "4";
+  }
+
+  if (fieldName.includes('range_')) {
+    return Math.round(69 * Math.random());
+  }
+
+  if (fieldName.includes('radio_')) {
+    return "nuggets";
+  }
+
+  if (fieldName.includes('radioButton_')) {
+    return "lime";
+  }
+
+  if (fieldName.includes('date_')) {
+    return "2025-04-27";
+  }
+
+  if (fieldName.includes('color_')) {
+    return "#e1b303";
+  }
+}
+
+const staticStates = {
+  "3ab3604bc6348ff85cfe175189af1e99": {
+    config: {},
+    enabled: true,
+    id: "3ab3604bc6348ff85cfe175189af1e99",
+    installation: "ready",
+    ip: "10.0.0.2",
+    manifest: {
+      config: {
+        sections: null,
+      },
+      container: {
+        build: {
+          nixFile: "pup.nix",
+          nixFileSha256: "",
+        },
+        exposes: [
+          {
+            port: 8080,
+            trafficType: "http",
+            type: "admin",
+          },
+          {
+            port: 8081,
+            trafficType: "http",
+            type: "admin",
+          },
+        ],
+        services: [
+          {
+            command: {
+              cwd: "",
+              env: null,
+              exec: "/bin/server1",
+            },
+            name: "server1",
+          },
+          {
+            command: {
+              cwd: "",
+              env: null,
+              exec: "/bin/server2",
+            },
+            name: "server2",
+          },
+        ],
+      },
+      dependencies: null,
+      manifestVersion: 1,
+      meta: {
+        logoPath: "",
+        name: "s1w test pup",
+        version: "0.0.5",
+      },
+      permissionGroups: null,
+    },
+    needsConf: false,
+    needsDeps: false,
+    source: {
+      location: "https://github.com/SomeoneWeird/test-pup.git",
+      name: "adamspup",
+      type: "git",
+    },
+    version: "0.0.5",
+  },
+};

--- a/src/components/layouts/standard/renders/nav.js
+++ b/src/components/layouts/standard/renders/nav.js
@@ -45,12 +45,12 @@ export function renderNav(CURPATH) {
             </a>
           </div>
 
-          <div class="nav-footer">
+          <!-- <div class="nav-footer">
             <div class="connection online">
               <sl-icon name="cloud-check-fill"></sl-icon>
               Connected
             </div>
-          </div>
+          </div> -->
         </div>
       </div>
     </nav>

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -3,6 +3,7 @@
     html,
     css,
     nothing,
+    classMap
   } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
   class PupCard extends LitElement {
@@ -36,6 +37,10 @@
 
     render() {
       const { pupName, version, icon, status, hasGui, href, gref } = this;
+      const statusClassMap = classMap({
+        status: true,
+        running: status === "running"
+      });
       return html`
         <a class="anchor" href=${href} target="_self">
           <div class="pup-card-wrap">
@@ -47,7 +52,7 @@
               <div class="inner">
                 <span class="name">${pupName}</span>
                 <span class="version">${version}</span>
-                <span class="status">${status === "running" ? "Enabled" : status}</span>
+                <span class=${statusClassMap}>${status === "running" ? "Enabled" : status}</span>
               </div>
             </div>
 
@@ -157,8 +162,12 @@
       span.status {
         line-height: 1.5;
         text-transform: capitalize;
-        color: #2ede75;
         font-size: 0.9rem;
+        color: grey;
+      }
+
+      span.status.running {
+        color: #2ede75;
       }
     `;
   }

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -48,8 +48,8 @@ class PupPage extends LitElement {
     super.connectedCallback();
     // Observers with a pupId will be requested to
     // update when state for that pup changes
-    this.pupId = this.context.store.pupContext.manifest.id;
-    this.pupEnabled = this.pkgController.getPup(this.pupId)?.state?.enabled
+    this.pupId = this.context.store.pupContext.id;
+    this.pupEnabled = this.pkgController.getPup(this.pupId)?.enabled
     this.pkgController.addObserver(this);
   }
 
@@ -161,7 +161,7 @@ class PupPage extends LitElement {
 
   render() {
     const path = this.context.store?.appContext?.path || [];
-    const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+    const pkg = this.pkgController.getPup(this.context.store.pupContext.id);
     const { installationId, statusId, statusLabel } = pkg.computed
     const hasChecks = (pkg?.manifest?.checks || []).length > 0;
     const isLoadingStatus =  ["starting", "stopping", "uninstalling"].includes(statusId);
@@ -186,7 +186,7 @@ class PupPage extends LitElement {
     const renderMenu = () => html`
       <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
         Enable or disable this Pup
-        <sl-switch slot="suffix" ?checked=${!disableActions && pkg.state.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight || installationId !== "ready"}></sl-switch>
+        <sl-switch slot="suffix" ?checked=${!disableActions && pkg.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight || installationId !== "ready"}></sl-switch>
       </action-row>
 
       <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -11,7 +11,7 @@ export function openDeps() {
 }
 
 export function renderActions() {
-  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const pkg = this.pkgController.getPup(this.pupId);;
   const { installationId, statusId, statusLabel } = pkg.computed
 
   const hasButtons =

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -31,8 +31,8 @@ export function renderDialog() {
 
   const configEl = html`
     <dynamic-form
-      .values=${pkg?.state?.config}
-      .fields=${pkg?.manifest?.command?.config}
+      .values=${pkg?.config}
+      .fields=${pkg?.manifest?.config}
       .onSubmit=${this.submitConfig}
       requireCommit
       markModifiedFields

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -1,7 +1,7 @@
 import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderStatus() {
-  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const pkg = this.pkgController.getPup(this.pupId);
   const { statusId, statusLabel } = pkg.computed;
   const isLoadingStatus = ["starting", "stopping", "crashing"].includes(statusId);
   const styles = css`

--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -1,7 +1,7 @@
 import { LitElement, html, css, nothing, repeat } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
 import '/components/views/card-pup-manage/index.js'
 import '/components/common/paginator/paginator-ui.js';
-import { getBootstrap } from '/api/bootstrap/bootstrap.js';
+import { getBootstrapV2 } from '/api/bootstrap/bootstrap.js';
 import { pkgController } from '/controllers/package/index.js'
 import { PaginationController } from '/components/common/paginator/paginator-controller.js';
 import { bindToClass } from '/utils/class-bind.js'
@@ -102,10 +102,9 @@ class LibraryView extends LitElement {
     this.dispatchEvent(new CustomEvent('busy-start', {}));
 
     try {
-      const res = await getBootstrap()
-      this.pkgController.setData(res);
-      this.installedList.setData(this.pkgController.installed);
-      // this.availableList.setData(this.pkgController.available);
+      const res = await getBootstrapV2()
+      this.pkgController.setDataV2(res);
+      this.installedList.setData(this.pkgController.installedV2);
     } catch (err) {
       console.error(err);
       this.fetchError = true;

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -61,16 +61,16 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('installed') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.installedList.getCurrentPageData(), (pkg) => `${pkg.manifest.id}-${pkg.manifest.version}`, (pkg) => html`
+        ${repeat(this.installedList.getCurrentPageData(), (pkg) => `${pkg.id}-${pkg.version}`, (pkg) => html`
           <pup-card
             icon="box"
-            pupId=${pkg.manifest.id}
-            pupName=${pkg.manifest.package}
-            version=${pkg.manifest.version}
-            status=${pkg.state.status}
+            pupId=${pkg.id}
+            pupName=${pkg.manifest.meta.name}
+            version=${pkg.version}
+            status=${pkg.computed.statusLabel}
             href=${pkg.computed.url.library}
             gref=${pkg.computed.url.ui}
-            ?hasGui=${!!pkg.manifest.gui}
+            ?hasGui=${!!pkg.manifest.gui} // TOMOO
           ></pup-card>
         `)}
       </div>

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -42,8 +42,12 @@ class PupInstallPage extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.pupId = this.context.store.pupContext.manifest.id;
+    this.pupId = this.context.store.pupDefinitionContext.id;
     this.pkgController.addObserver(this);
+    this.pkg = this.pkgController.getPupDefinition(
+      this.context.store.pupDefinitionContext.source.id,
+      this.context.store.pupDefinitionContext.id
+    );
   }
 
   disconnectedCallback() {
@@ -71,7 +75,7 @@ class PupInstallPage extends LitElement {
 
   render() {
     const path = this.context.store?.appContext?.path || [];
-    const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+    const pkg = this.pkg
     const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
     const isLoadingStatus = ["installing"].includes(statusId);
     const hasDependencies = (pkg?.manifest?.deps?.pups || []).length > 0
@@ -101,7 +105,7 @@ class PupInstallPage extends LitElement {
           <div class="section-title">
             <h3>Description</h3>
             <reveal-row>
-              <p>${pkg?.manifest?.docs?.short}<br/>${pkg?.manifest?.docs?.long}</p>
+              <p>${pkg?.versionLatest?.meta?.descShort}<br/>${pkg?.versionLatest?.meta?.descLong}</p>
             </reveal-row>
           </div>
         </section>

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -6,7 +6,7 @@ export function openConfig() {
 }
 
 export function renderActions() {
-  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const pkg = this.pkg
   const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
   const styles = css`
     .action-wrap {

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -21,12 +21,12 @@ export function renderActions() {
       }
     }
   `
-  const isInstalled = !!pkg?.state?.status;
+  const isInstalled = pkg.isInstalled
 
   return html`
     <div class="action-wrap">
 
-      ${["not_installed", "uninstalled"].includes(installationId) ? html`
+      ${!isInstalled ? html`
         <sl-button variant="warning" size="large"
           @click=${this.handleInstall}
           ?disabled=${this.inflight}
@@ -35,13 +35,13 @@ export function renderActions() {
         </sl-button>
       ` : nothing }
 
-      ${installationId === "installing" ? html`
+      ${!isInstalled && installationId === "installing" ? html`
         <sl-button variant="warning" size="large" disabled>
           Installing <sl-spinner slot="suffix" style="--indicator-color:#222"></sl-spinner>
         </sl-button>
       ` : nothing }
 
-      ${["ready", "unready"].includes(installationId) ? html`
+      ${isInstalled ? html`
         <sl-button variant="primary" size="large" href="${pkg.computed.url.library}">
           Manage
         </sl-button>

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -3,18 +3,20 @@ import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min
 export function renderStatus() {
   const pkg = this.pkg
   const { installationId, installationLabel } = pkg.computed
+  const isInstalled = pkg.isInstalled
   const isLoadingStatus = ["installing"].includes(installationId);
+
   const normalisedLabel = () => {
-    if (["not_installed", "uninstalled"].includes(installationId)) {
+    if (!isInstalled) {
       return "Not installed"
     } else {
-      return installationLabel
+      return "Installed"
     }
   }
 
   return html`
     <div class="section-title">
-      <h3 class="installation-label ${installationId}">${normalisedLabel()}</h3>
+      <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
     </div>
     <div>
       <span class="status-label">${pkg.versionLatest.meta.name}</span>

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -1,7 +1,7 @@
 import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderStatus() {
-  const pkg = this.pkgController.getPup(this.context.store.pupContext.manifest.id);
+  const pkg = this.pkg
   const { installationId, installationLabel } = pkg.computed
   const isLoadingStatus = ["installing"].includes(installationId);
   const normalisedLabel = () => {
@@ -17,7 +17,7 @@ export function renderStatus() {
       <h3 class="installation-label ${installationId}">${normalisedLabel()}</h3>
     </div>
     <div>
-      <span class="status-label">${pkg.manifest.package}</span>
+      <span class="status-label">${pkg.versionLatest.meta.name}</span>
       <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
     </div>
     <style>${styles}</style>

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -1,5 +1,5 @@
 import { LitElement, html, css, nothing, repeat } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
-import { getBootstrap } from '/api/bootstrap/bootstrap.js';
+import { getStoreListing } from '/api/sources/sources.js';
 import { pkgController } from '/controllers/package/index.js'
 import { PaginationController } from '/components/common/paginator/paginator-controller.js';
 import { bindToClass } from '/utils/class-bind.js'
@@ -9,8 +9,8 @@ import '/components/common/paginator/paginator-ui.js';
 import '/components/common/page-banner.js';
 
 const initialSort = (a, b) => {
-  if (a.manifest.package < b.manifest.package) { return -1; }
-  if (a.manifest.package > b.manifest.package) { return 1; }
+  if (a.versionLatest.meta.name < b.versionLatest.meta.name) { return -1; }
+  if (a.versionLatest.meta.name > b.versionLatest.meta.name) { return 1; }
   return 0;
 }
 
@@ -113,9 +113,9 @@ class StoreView extends LitElement {
     this.dispatchEvent(new CustomEvent('busy-start', {}));
 
     try {
-      const res = await getBootstrap()
-      this.pkgController.setData(res);
-      this.packageList.setData(this.pkgController.packages);
+      const res = await getStoreListing()
+      this.pkgController.ingestAvailablePupDefs(res);
+      this.packageList.setData(this.pkgController.availablePackagesAll);
     } catch (err) {
       console.error(err);
       this.fetchError = true;
@@ -170,10 +170,12 @@ class StoreView extends LitElement {
     return html`
       <page-banner title="Dogecoin" subtitle="Registry">
         Extend your Dogebox with Pups<br/>
+        <!--
         <sl-button variant="text">
           <sl-icon name="arrow-left-right" slot="prefix"></sl-icon>
           Change Registry
         </sl-button>
+        -->
       </page-banner>
 
       <div class="row search-wrap">

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -52,17 +52,15 @@ export function renderSectionBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('packages') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.manifest.id}-${pkg.manifest.version}`, (pkg) => html`
+        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.source.id}-${pkg.id}`, (pkg) => html`
           <pup-install-card
             icon="box"
-            pupId=${pkg.manifest.id}
-            pupName=${pkg.manifest.package}
-            version=${pkg.manifest.version}
-            short=${pkg.manifest.docs.short}
-            status=${pkg.state.status}
-            ?installed=${pkg.state.status}
-            ?hasGui=${!!pkg.manifest.gui}
-            href="${pkg.computed.url.store}"
+            pupId="${pkg.source.id}-${pkg.id}"
+            pupName=${pkg.versionLatest.meta.name}
+            version=${pkg.versionLatest.version}
+            short=${pkg.versionLatest.meta.descShort}
+            ?installed=${pkg.isInstalled}
+            href=${pkg.computed.url.store}
           ></pup-install-card>
         `)}
       </div>

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -1,4 +1,4 @@
-import { loadPup, asPage, performLogout } from "./middleware.js"
+import { loadPup, loadPupDefinition, asPage, performLogout } from "./middleware.js"
 
 export const routes = [
   {
@@ -42,7 +42,7 @@ export const routes = [
     animate: true,
   },
   {
-    path: "/pups/:pup/:name/logs",
+    path: "/pups/:s/:name/logs",
     component: "x-page-pup-logs",
     pageTitle: "Logs",
     pageAction: "close",
@@ -56,11 +56,11 @@ export const routes = [
     before: [asPage],
   },
   {
-    path: "/explore/:pup/:name",
+    path: "/explore/:source/:pup",
     component: "x-page-pup-store-listing",
     dynamicTitle: true,
     pageAction: "back",
-    before: [loadPup, asPage],
+    before: [loadPupDefinition, asPage],
     animate: true,
   },
   {

--- a/src/router/middleware.js
+++ b/src/router/middleware.js
@@ -56,7 +56,7 @@ export async function loadPupDefinition(context, commands) {
     });
 
     if (context.route.dynamicTitle) {
-      context.route.pageTitle = pup?.latestVersion?.meta?.name;
+      context.route.pageTitle = pup?.versionLatest?.meta?.name;
       context.route.pageAction = "back";
     }
 

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -32,6 +32,9 @@ class Store {
       state: {},
       computed: {},
     };
+    this.pupDefinitionContext = {
+      computed: {},
+    };
     this.promptContext = {
       display: false,
       name: "transaction",
@@ -109,6 +112,9 @@ class Store {
     }
     if (partialState.pupContext) {
       this.pupContext = { ...this.pupContext, ...partialState.pupContext };
+    }
+    if (partialState.pupDefinitionContext) {
+      this.pupDefinitionContext = { ...this.pupDefinitionContext, ...partialState.pupDefinitionContext };
     }
     if (partialState.promptContext) {
       this.promptContext = {


### PR DESCRIPTION
### Please note

Could be bumpy.  This is a draft.

### Summary: 

> This PR does the bulk of the cutover to the adjusted apis and data structure responsible for listing installed and available pups.

### Specific objectives: 

Using mocks of the V2 data structure, do the following:

- [X] Render the Library list
- [X] Render the Library item page
- [X] Render the Store list
- [X] Render the Store Item page

Without mocks:

- [X] When mocks are off, correct endpoints are hit
- [X] Render from data returned from server

---

### Library 
(rendering from generated v2 data struct)
![image](https://github.com/user-attachments/assets/9b172d7f-5445-45ac-a167-c33be186c568)

### Store 
(rendering from generated v2 data struct)
![image](https://github.com/user-attachments/assets/69955e17-dc91-4e3a-808b-2fbe1b8613c9)

Some small liberties taken in extending/adjusting the structure to be discussed. Eg:
- descShort / descLong added to meta
- versionInstalled, versionLatest, hasUpdates
