### PR TITLE
Pup lifecycle complete PLUS base URLs

### DIFF
--- a/src/api/action/action.js
+++ b/src/api/action/action.js
@@ -9,7 +9,7 @@ import {
   purgeMock
 } from './action.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function installPup(pupId, body) {
   return client.put(`/pup`, body, { mock: installMock });

--- a/src/api/bootstrap/bootstrap.js
+++ b/src/api/bootstrap/bootstrap.js
@@ -1,9 +1,10 @@
 import ApiClient from '/api/client.js';
 import { store } from '/state/store.js'
+import { pkgController } from '/controllers/package/index.js';
 import { mock } from './bootstrap.mocks.js'
 import { mockV2 } from './bootstrap.mocks.v2.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getBootstrap() {
   return client.get('/setup/bootstrap', { mock });
@@ -11,4 +12,8 @@ export async function getBootstrap() {
 
 export async function getBootstrapV2() {
   return client.get('/system/bootstrap', { mock: mockV2 })
+}
+
+export async function doBootstrap() {
+  return pkgController.setData(await getBootstrapV2());
 }

--- a/src/api/config/config.js
+++ b/src/api/config/config.js
@@ -7,7 +7,7 @@ import {
   getAllResponse,
 } from './config.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function postConfig(pupId, body) {
   return client.post(`/config/${pupId}`, body, { mock: postResponse });

--- a/src/api/keys/create-key.js
+++ b/src/api/keys/create-key.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './create-key.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function createKey(password) {
   const res = await client.post(`/keys/create-master`, { password }, { mock: postResponse });

--- a/src/api/keys/get-keylist.js
+++ b/src/api/keys/get-keylist.js
@@ -3,7 +3,7 @@ import { store } from "/state/store.js";
 
 import { getResponse } from "./get-keylist.mocks.js";
 
-const client = new ApiClient("http://localhost:3000", store.networkContext);
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext);
 
 export async function getKeylist() {
   const res = await client.get(`/keys`, { mock: getResponse });

--- a/src/api/login/login.js
+++ b/src/api/login/login.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './login.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function postLogin(body) {
   const res = await client.post(`/authenticate`, body, { mock: postResponse });

--- a/src/api/manifest/manifest.js
+++ b/src/api/manifest/manifest.js
@@ -5,7 +5,7 @@ import {
   generateManifests
 } from './manifest.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getManifest() {
   return client.get('/manifest/', { mock: generateManifests });

--- a/src/api/network/get-networks.js
+++ b/src/api/network/get-networks.js
@@ -5,7 +5,7 @@ import {
   getResponse,
 } from './get-networks.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getNetworks(body) {
   const res = await client.get(`/system/network/list`, { mock: getResponse });

--- a/src/api/network/set-network.js
+++ b/src/api/network/set-network.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './set-network.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function putNetwork(body) {
   const res = await client.put(`/system/network/set-pending`, body, { mock: postResponse });

--- a/src/api/password/change-pass.js
+++ b/src/api/password/change-pass.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './change-pass.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function postChangePass(body) {
   const res = await client.post(`/auth/change-pass`, body, { mock: postResponse });

--- a/src/api/reflector/get-ip.js
+++ b/src/api/reflector/get-ip.js
@@ -5,7 +5,7 @@ import {
   getResponse,
 } from './get-ip.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getIP() {
   const res = await client.get(`/reflector/ip`, { mock: getResponse });

--- a/src/api/sockets.js
+++ b/src/api/sockets.js
@@ -17,6 +17,7 @@ export default class WebSocketClient {
     if (this.useMocks && this.mockEventGenerator) {
       this.startMocking();
     } else {
+      if (!this.token) return
       this.startWebSocketConnection();
     }
   }

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -5,7 +5,7 @@ import {
   storeListingMock
 } from './sources.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getStoreListing() {
   return client.get('/sources/store', { mock: storeListingMock });

--- a/src/api/system/get-bootstrap.js
+++ b/src/api/system/get-bootstrap.js
@@ -5,7 +5,7 @@ import {
   getResponse,
 } from './get-bootstrap.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function getSetupBootstrap(body) {
   const res = await client.get(`/system/bootstrap`, { mock: getResponse });

--- a/src/api/system/post-bootstrap.js
+++ b/src/api/system/post-bootstrap.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './post-bootstrap.mocks.js'
 
-const client = new ApiClient('http://localhost:3000', store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function postSetupBootstrap(body) {
   const res = await client.post(`/system/bootstrap`, body, { mock: postResponse });

--- a/src/app.js
+++ b/src/app.js
@@ -123,11 +123,9 @@ class DPanelApp extends LitElement {
   async fetchBootstrap() {
     try {
       const res = await getBootstrapV2()
-      this.pkgController.setData(res);
+      if (res) { this.pkgController.setData(res); }
     } catch (err) {
-      console.error(err);
-    } finally {
-      // this.fetchLoading = false
+      // TODO. improve unauthorised handling
     }
   }
 

--- a/src/components/common/page-container.js
+++ b/src/components/common/page-container.js
@@ -168,7 +168,6 @@ class PageContainer extends LitElement {
 function navigateBack(store, router) {
   // Retrieve path stack from the store
   const pathStack = store.appContext.pathStack;
-  console.log({ pathStack });
 
   // Check if there is more than one path in the stack
   if (pathStack.length > 1) {

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -78,7 +78,7 @@ class LogViewer extends LitElement {
     }
 
     this.wsClient = new WebSocketClient(
-      `ws://localhost:3000/logs/${this.pupId}`,
+      `${store.networkContext.WsApiBaseUrl}/logs/${this.pupId}`,
       store.networkContext,
       mockedLogRunner
     );

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -41,7 +41,7 @@ class SocketChannel {
     }
 
     this.wsClient = new WebSocketClient(
-      "ws://localhost:3000/ws/state/",
+      `${store.networkContext.wsApiBaseUrl}/ws/state/`,
       store.networkContext,
       mockedMainChannelRunner,
     );
@@ -59,9 +59,6 @@ class SocketChannel {
       let err, data;
       try {
         data = JSON.parse(event.data);
-        if (data?.update && data.update[0] && data.update[0]?.status) {
-          // console.log("REPORTED STATUS:", data.update[0].status, data);
-        }
       } catch (err) {
         console.warn("failed to JSON.parse incoming event", event, err);
         err = true;
@@ -78,7 +75,6 @@ class SocketChannel {
       switch (data.type) {
         case "pup":
           // emitted on state change (eg: installing, ready)
-          console.log("PUP EVENT RECEIVED:", data.update.id, data.update.installation, data.update)
           pkgController.updatePupModel(data.update.id, data.update)
           break;
 
@@ -86,7 +82,6 @@ class SocketChannel {
           // emitted on an interval (contains current status and vitals)
           if (data && data.update && Array.isArray(data.update)) {
             data.update.forEach((statsUpdatePayload) => {
-              console.log('stats', statsUpdatePayload.status, statsUpdatePayload.id);
               pkgController.updatePupStatsModel(statsUpdatePayload.id, statsUpdatePayload)
             });
           }

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -26,7 +26,7 @@ export function renderDialog() {
   const uninstallEl = html`
     <p>Are you sure you want to uninstall ${pkg.manifest.meta.name}?</p>
     <sl-input placeholder="Type '${pkg.manifest.meta.name}' to confirm" @sl-input=${(e) => this._confirmedName = e.target.value }></sl-input>
-    <sl-button slot="footer" variant="danger" @click=${this.handleUninstall} ?loading=${this.inflight} ?disabled=${this.inflight || this._confirmedName !== pkg.manifest.meta.name}>Uninstall</sl-button>
+    <sl-button slot="footer" variant="danger" @click=${this.handleUninstall} ?loading=${this.inflight_uninstall} ?disabled=${this.inflight_uninstall || this._confirmedName !== pkg.manifest.meta.name}>Uninstall</sl-button>
     <style>p:first-of-type { margin-top: 0px; }</style>
   `;
 

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -1,10 +1,9 @@
 import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
-export function renderStatus() {
-  const pupContext = this.context.store?.pupContext
-  const pkg = this.pkgController.getPup(pupContext.id);
-  const { statusId, statusLabel } = pkg.computed;
-  const isLoadingStatus = ["starting", "stopping", "crashing"].includes(statusId);
+export function renderStatus(labels) {
+  const { statusId, statusLabel, installationId, installationLabel } = labels;
+  const isInstallationLoadingStatus = ["uninstalling", "purging"].includes(installationId)
+
   const styles = css`
     :host {
       --color-neutral: #8e8e9a;
@@ -29,14 +28,20 @@ export function renderStatus() {
 
       &.broken { color: var(--sl-color-danger-600);}
       &.uninstalling { color: var(--sl-color-danger-600); }
-      &.uninstalled { color: var(--color-neutral); }
+      &.uninstalled { color: var(--sl-color-danger-600); }
+      &.purging { color: var(--sl-color-danger-600); }
     }
   `
 
   return html`
-    <span class="status-label ${statusId}">
-      ${statusLabel}
-    </span>
+
+    ${installationId === "uninstalled"
+      ? html`<span class="status-label ${installationId}">${installationLabel}</span>`
+      : isInstallationLoadingStatus
+        ? html`<span class="status-label ${installationId}">${installationLabel}</span>`
+        : html`<span class="status-label ${statusId}">${statusLabel}</span>`
+    }
+
     <style>${styles}</style>
   `
 };

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -104,6 +104,8 @@ class PupInstallPage extends LitElement {
     const path = this.context.store?.appContext?.path || [];
     const pkg = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
 
+    if (!pkg) return;
+
     const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
     const hasDependencies = (pkg?.manifest?.deps?.pups || []).length > 0
     const popover_page = path[1];

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -74,9 +74,9 @@ export async function handleInstall() {
   const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
   this.inflight = true;
   const callbacks = {
-    onSuccess: () => { console.log('WOW'); this.inflight = false; },
-    onError: () => { console.log('NOO..'); this.inflight = false; },
-    onTimeout: () => { console.log('TOO SLOW..'); this.inflight = false; }
+    onSuccess: () => { this.inflight = false; },
+    onError: () => { console.log('Txn reported an error'); this.inflight = false; },
+    onTimeout: () => { console.log('Slow txn, no repsonse within ~30 seconds (install)'); this.inflight = false; }
   }
   const body = {
     sourceName: def.source.id,

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -5,8 +5,6 @@ export function renderStatus() {
   const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
   const pkg = this.pkgController.getPupByDefinitionData(pupDefinitionContext?.source?.id, pupDefinitionContext?.id)
 
-  console.log('pkg view', {def, pkg}, );
-
   const installationId = pkg?.computed?.installationId;
   const installationLabel = pkg?.computed?.installationLabel;
 

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -1,11 +1,11 @@
-import { loadPup, loadPupDefinition, asPage, performLogout } from "./middleware.js"
+import { isAuthed, loadPup, loadPupDefinition, asPage, performLogout } from "./middleware.js"
 
 export const routes = [
   {
     path: "/",
     component: "x-page-home",
     pageTitle: "Home",
-    before: [asPage]
+    before: [isAuthed, asPage]
   },
   {
     path: "/logout",
@@ -19,26 +19,26 @@ export const routes = [
     path: "/stats",
     component: "x-page-stats",
     pageTitle: "Stats",
-    before: [asPage]
+    before: [isAuthed, asPage]
   },
   {
     path: "/settings",
     component: "x-page-settings",
     pageTitle: "Settings",
-    before: [asPage]
+    before: [isAuthed, asPage]
   },
   {
     path: "/pups",
     component: "x-page-pup-library",
     pageTitle: "Installed Pups",
-    before: [asPage]
+    before: [isAuthed, asPage]
   },
   {
     path: "/pups/:pup/:name",
     component: "x-page-pup-library-listing",
     dynamicTitle: true,
     pageAction: "back",
-    before: [asPage],
+    before: [isAuthed, asPage],
     after: [loadPup],
     animate: true,
   },
@@ -47,7 +47,7 @@ export const routes = [
     component: "x-page-pup-logs",
     pageTitle: "Logs",
     pageAction: "close",
-    before: [asPage],
+    before: [isAuthed, asPage],
     after: [loadPup],
     animate: true,
   },
@@ -55,14 +55,14 @@ export const routes = [
     path: "/explore",
     component: "x-page-pup-store",
     pageTitle: "Explore Pups",
-    before: [asPage],
+    before: [isAuthed, asPage],
   },
   {
     path: "/explore/:source/:name",
     component: "x-page-pup-store-listing",
     dynamicTitle: true,
     pageAction: "back",
-    before: [asPage],
+    before: [isAuthed, asPage],
     after: [loadPupDefinition],
     animate: true,
   },
@@ -71,7 +71,7 @@ export const routes = [
     component: "x-page-pup-iframe",
     dynamicTitle: true,
     pageAction: "close",
-    before: [loadPup, asPage],
+    before: [isAuthed, asPage],
     animate: true
   }
 ]

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -16,12 +16,14 @@ class Store {
     };
     this.networkContext = this.networkContext || {
       // Define network state here
-      apiBaseUrl: "http://localhost:3000",
+      apiBaseUrl: `${window.location.protocol}//${window.location.hostname}:3000`,
+      wsApiBaseUrl: `ws://${window.location.hostname}:3000`,
       overrideBaseUrl: false,
-      useMocks: true,
+      overrideSocketBaseUrl: false,
+      useMocks: false,
       forceFailures: false,
       forceDelayInSeconds: 0,
-      reqLogs: true,
+      reqLogs: false,
       status: "online",
       token: false,
       demoSystemPrompt: "",

--- a/src/utils/debug-settings.js
+++ b/src/utils/debug-settings.js
@@ -200,6 +200,25 @@ class DebugSettingsDialog extends LitElement {
             </sl-input>
           </div>
           <div class="form-control">
+            <sl-switch
+              name="overrideBaseUrl"
+              help-text="Force API calls to use base URL below"
+              .checked=${networkContext.overrideSocketBaseUrl}
+              @sl-change=${this.handleToggle}>
+                Override Web Socket Base URL
+            </sl-input>
+          </div>
+          <div class="form-control">
+            <sl-input
+              type="text"
+              name="wsApiBaseUrl"
+              help-text="Web Socket connections wii use this base URL"
+              value=${networkContext.wsApiBaseUrl}
+              @sl-change=${this.handleInput}>
+                Web Socket Base URL
+            </sl-input>
+          </div>
+          <div class="form-control">
             <sl-input
               type="text"
               name="demoSystemPrompt"


### PR DESCRIPTION
This PR has two primary objectives:

Rendering pup state labels and actions;
- [X] Uninstalling
- [X] Purging and navigate to /pups after purge
- [X] Calls bootstrap after purge.

API endpoints:
- [X] Allow both REST and WebSocket endpoints to be overriden 
- [X] Set default values to window.location values

Additionally:
- This PR removes a bunch of dev noise logs
- Spreads isAuthed middleware across needed pages
- Prevents socket connection attempt if !token