### PR TITLE
Fix - Safari Routing & App Start

### DIFF
--- a/src/components/layouts/standard/styles/main.styles.js
+++ b/src/components/layouts/standard/styles/main.styles.js
@@ -15,6 +15,13 @@ export const mainStyles = css`
     font-style: normal;
   }
 
+  .loader-overlay {
+    height: calc(100vh - 3em);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   #Main {
     flex-grow: 1;
     

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -3,6 +3,7 @@ import { store } from "/state/store.js";
 import { pkgController } from "/controllers/package/index.js";
 import { asyncTimeout } from "/utils/timeout.js";
 import { performMockCycle, c1, c4, c5 } from "/api/mocks/pup-state-cycle.js";
+import { isUnauthedRoute } from "/utils/url-utils.js";
 
 async function mockedMainChannelRunner(onMessageCallback) {
   if (store.networkContext.demoSystemPrompt) {
@@ -31,12 +32,16 @@ class SocketChannel {
     this.setupSocketConnection();
 
     if (!this.isConnected) {
-      this.wsClient.connect();
+      this.wsClient && this.wsClient.connect();
     }
   }
 
   setupSocketConnection() {
     if (this.isConnected) {
+      return;
+    }
+
+    if (isUnauthedRoute()) {
       return;
     }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -8,11 +8,6 @@ export class Router {
 
     this.setupLinkInterceptor();
 
-    // Ensure route is processed on app start (else no component).
-    window.onload = () => {
-      this.handleNavigation(window.location.pathname);
-    };
-
     // Ensure route is processed on popstate (eg: browser back button)
     // Else no component.
     window.onpopstate = () => {
@@ -24,6 +19,10 @@ export class Router {
     routes.forEach((route) => {
       this.addRoute(route.path, route.component, route);
     });
+  }
+
+  processCurrentRoute() {
+    this.handleNavigation(window.location.pathname);
   }
 
   addRoute(path, component, route) {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,3 +1,5 @@
+import { isUnauthedRoute, hasFlushParam } from "/utils/url-utils.js";
+
 class Store {
   subscribers = [];
 
@@ -45,13 +47,13 @@ class Store {
       hashedPassword: null,
       view: null,
     };
+
     // Hydrate state from localStorage unless flush parameter is present.
-    const CURRENT_HREF = window.location.href; 
-    if (!["/login", "/logout", "?flush"].includes(CURRENT_HREF)) {
+    if (!isUnauthedRoute() && !hasFlushParam()) {
       this.hydrate();
-      if (CURRENT_HREF.includes("?flush")) {
-        window.location = window.location.origin + window.location.pathname;
-      }
+    }
+    if (hasFlushParam()) {
+      window.location = window.location.origin + window.location.pathname;
     }
   }
 

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -1,0 +1,16 @@
+export function isUnauthedRoute() {
+  const pathname = window.location.pathname;
+
+  if (pathname.startsWith('/login')) {
+    return true;
+  }
+
+  if (pathname.startsWith('/logout')) {
+    return true;
+  }
+}
+
+export function hasFlushParam() {
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams.has('flush');
+}


### PR DESCRIPTION
This PR primary addresses the app routing issues in Safari 

The result is a clean cutover from recovery to standard mode.

Changes:
- Router now processes initial landing page correctly on Safari (no reliance on `window.onload`)
- Don't bootstrap on /login /logout routes
- Never hydrate state from localStorage on /login, /logout or when ?flush is present.
- App now has an unready state, show's a spinner.

This combination of changes makes a smooth experience cross browser, see below:
![cutover-safari](https://github.com/user-attachments/assets/50259ad9-6784-4a3a-8d0b-029c0784fd29)

