### PR TITLE
Mono object

### DIFF
--- a/src/api/mocks/pup-state-cycle.js
+++ b/src/api/mocks/pup-state-cycle.js
@@ -60,7 +60,7 @@ export const c5 = [
   ["ready", "stopped"]
 ]
 
-export const installEvent = {
+export const mockInstallEvent = {
   "id": "internal",
   "error": "",
   "type": "pup",

--- a/src/api/mocks/pup-state-cycle.js
+++ b/src/api/mocks/pup-state-cycle.js
@@ -59,3 +59,70 @@ export const c5 = [
   ["ready", "stopping"],
   ["ready", "stopped"]
 ]
+
+export const installEvent = {
+  "id": "internal",
+  "error": "",
+  "type": "pup",
+  "update": {
+    "id": "23956456098893245a104cb39e9c055f",
+    "source": {
+      "id": "b215d6a7bcf215ca00e02f9cb6a41d12",
+      "name": "s1w test pup",
+      "description": "",
+      "location": "https://github.com/SomeoneWeird/test-pup.git",
+      "type": "git"
+    },
+    "manifest": {
+      "manifestVersion": 1,
+      "meta": {
+        "name": "s1w test pup",
+        "version": "0.0.8",
+        "logoPath": "",
+        "shortDescription": "my little test pup",
+        "longDescription": "this pup has two services that run in it, server1 and server2. They each host a http server on port 8080 and 8081 respectively."
+      },
+      "config": { "sections": null },
+      "container": {
+        "build": {
+          "nixFile": "pup.nix",
+          "nixFileSha256": "bb405c5f11b287cf8f01fd9d8dc504ffe43f2efa9ba292902e761c8670d798eb"
+        },
+        "services": [
+          {
+            "name": "server1",
+            "command": { "exec": "/bin/server1", "cwd": "", "env": null }
+          },
+          {
+            "name": "server2",
+            "command": { "exec": "/bin/server2", "cwd": "", "env": null }
+          }
+        ],
+        "exposes": [
+          {
+            "type": "admin",
+            "trafficType": "http",
+            "port": 8080,
+            "interfaces": null
+          },
+          {
+            "type": "admin",
+            "trafficType": "http",
+            "port": 8081,
+            "interfaces": null
+          }
+        ]
+      },
+      "interfaces": null,
+      "dependencies": []
+    },
+    "config": {},
+    "providers": null,
+    "installation": "installing",
+    "enabled": false,
+    "needsConf": false,
+    "needsDeps": false,
+    "ip": "10.0.0.16",
+    "version": "0.0.8"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -118,10 +118,10 @@ class DPanelApp extends LitElement {
     this.router.processCurrentRoute();
 
     // Hide menu on page change
-    this.router.addHook(() => store.updateState({ appContext: { menuVisible: false }}))
+    this.router.addAfterHook(() => store.updateState({ appContext: { menuVisible: false }}))
 
     // Clear some contexts on route change
-    this.router.addHook(() => store.clearContext(['pupContext', 'pupDefinitionContext']));
+    this.router.addBeforeHook(() => store.clearContext(['pupContext']));
 
     if (isUnauthedRoute()) {
       setTimeout(() => { this.ready = true; }, 1500)

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -52,7 +52,7 @@
               <div class="inner">
                 <span class="name">${pupName}</span>
                 <span class="version">${version}</span>
-                <span class=${statusClassMap}>${status === "running" ? "Enabled" : status}</span>
+                <span class=${statusClassMap}>${status}</span>
               </div>
             </div>
 

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -5,13 +5,10 @@ class PkgController {
   observers = [];
   actions = [];
 
-  // Installed packages on system
-  installedPackageIndex = {};
-  installedPackages = [];
-
-  // Available packges to install.
-  packageDefinitionIndex = {};
-  pacakgeDefinitions = [];
+  pups = []
+  stateIndex = {}
+  statsIndex = {}
+  sourcesIndex = {}
 
   constructor() {
     this.transactionTimeoutChecker();
@@ -44,60 +41,151 @@ class PkgController {
     }
   }
 
-  ingestInstalledPup(states, stats) {
-    // Convert to array, enrich each state object.
-    this.installedPackages = toArray(states)
-      .filter(s => isValidState(s))
-      .map(s => toEnrichedInstalledPup(s.id, s, stats[s.id]));
-
-    // Index by id.
-    this.installedPackageIndex = this.installedPackages
-      .toObject({ key: 'id' });
-
-  }
-
-  ingestAvailablePupDefs(storeListingRes) {
-    this.packageDefinitionIndex = storeListingRes;
-    this.packageDefinitions = toFlattenedAvailablePupsArray(storeListingRes);
-    this.notify();
-  }
-
-  getPupDefinition(sourceId, pupId) {
-    const pup = this.packageDefinitions.find(
-      p => p.source.id === sourceId && p.id === pupId
-    );
-    return pup;
-  }
-
-  getInstalledVersion(sourceId, pupId) {
-    const pup = this.packageDefinitions.find(
-      p => p.source.id === sourceId && p.id === pupId
-    );
-    const installedVersion = pup.versions.find(
-      v => v.version === pup.installedVersion
-    )
-    return installedVersion;
-  }
-
   setData(bootstrapResponseV2) {
     const { states, stats } = bootstrapResponseV2;
-    this.ingestInstalledPup(states, stats);
+    this.handleBootstrapResponse(states, stats);
     this.notify();
   }
 
-  getPup(id) {
-    if (!id) return;
-    const key = Object.keys(this.installedPackageIndex).find(
-      (key) => key.toLowerCase() === id.toLowerCase(),
-    );
-    return this.installedPackageIndex[key];
+  setStoreData(storeListingRes) {
+    this.handleSourcesResponse(storeListingRes);
+    this.notify();
   }
 
-  getPupByDefinitionData(source, pupName) {
-    const pup = this.installedPackages.find(
-      p => p.source.name === source && p.manifest.meta.name === pupName
-    );
-    return pup;
+  handleBootstrapResponse(states, stats) {
+    this.stateIndex = states;
+    this.statsIndex = stats
+
+    for (const [stateKey, stateData] of Object.entries(states)) {
+
+      // Do we have this pup in memory?
+      const { pup, index } = this.getPupMaster({ pupId: stateKey })
+
+      // Update it in place.
+      if (pup) {
+        this.pups[index] = {
+          ...this.pups[index],
+          state: stateData,
+          stats: stats[stateKey]
+        }
+        this.pups[index].computed = {
+          ...this.pups[index].computed,
+          ...this.determineCalculatedVals(this.pups[index])
+        }
+      }
+
+      if (!pup) {
+        let newPup = {
+          computed: null,
+          def: null,
+          state: stateData,
+          stats: stats[stateKey],
+        }
+        newPup.computed = this.determineCalculatedVals(newPup);
+        this.pups.push(newPup);
+      }
+    }
+  }
+
+  determineCalculatedVals(pup) {
+    const isInstalled = !!pup.state
+    const status = determineStatusId(pup.state, pup.stats);
+    const installation = determineInstallationId(pup.state);
+    let out;
+    try {
+      out = {
+        isInstalled,
+        statusId: status.id,
+        statusLabel: status.label,
+        installationId: installation.id,
+        installationLabel: installation.label,
+        // Convention: /explore/:source_id/:pup_name
+        storeURL: isInstalled
+          ? `/explore/${pup.state.source.id}/${encodeURIComponent(pup.state.manifest.meta.name)}`
+          : `/explore/${pup.def.source.id}/${encodeURIComponent(pup.def.key)}`,
+        // Convention: /pups/:pup_id/:pup_name
+        libraryURL: isInstalled
+          ? `/pups/${pup.state.id}/${encodeURIComponent(pup.state.manifest.meta.name)}`
+          : null
+      }
+    } catch (err) {
+      console.error('error occurred with computed vals', error);
+    }
+    return out
+  }
+
+  handleSourcesResponse(sources) {
+    this.sourcesIndex = sources;
+
+    try {
+      for (const [sourceId, sourceData] of Object.entries(sources)) {
+        for (const [pkgName, pupDefinitionData] of Object.entries(sourceData.pups)) {
+
+          // Do we have this pup in memory?
+          const foundIndex = this.pups.findIndex(pup => (
+            (pup?.state?.source?.id === sourceId &&
+            pup?.state?.manifest?.meta?.name === pkgName)) ||
+            (pup?.def?.source?.id === sourceId &&
+            pup?.def?.key === pkgName)
+          )
+
+          const def = {
+            ...pupDefinitionData,
+            key: pkgName,
+            source: { id: sourceId, lastChecked: sourceData.lastChecked },
+          }
+
+          // Update it in place.
+          const found = foundIndex >= 0;
+          if (found) {
+            this.pups[foundIndex] = {
+              ...this.pups[foundIndex],
+              def
+            }
+            this.pups[foundIndex].computed = {
+              ...this.pups[foundIndex].computed,
+              ...this.determineCalculatedVals(this.pups[foundIndex])
+            }
+          }
+
+          // Not found. create and push to pups array.
+          if (!found) {
+            let pup = {
+              computed: null,
+              def,
+              state: null,
+              stats: null,
+            }
+            pup.computed = this.determineCalculatedVals(pup);
+            this.pups.push(pup)
+          }
+        }
+      }
+    } catch (definitionProcessingError) {
+      console.debug('Issue while processing pup definiions')
+      console.error(definitionProcessingError);
+    }
+  }
+
+  getPupMaster({ pupId, sourceId, pupName, lookupType }) {
+    try {
+      let result = null;
+      let index = -1;
+
+      if (this.stateIndex[pupId]) {
+        index = this.pups.findIndex(p => p.state.id === pupId);
+        result = index !== -1 ? this.pups[index] : null;
+      }
+
+      if (!result && this.sourcesIndex[sourceId] && this.sourcesIndex[sourceId].pups[pupName]) {
+        index = this.pups.findIndex(p => p.def.source.id === sourceId && p.def.key === pupName);
+        result = index !== -1 ? this.pups[index] : null;
+      }
+
+      return { pup: result, index };
+    } catch (err) {
+      return { pup: null, index: -1 };
+    }
   }
 
   registerAction(txn, callbacks, actionType, pupId, timeout) {
@@ -136,13 +224,16 @@ class PkgController {
       actionType,
       pupId,
       issuedAt,
-      expireAt
+      expireAt,
     });
   }
 
   resolveAction(txn, payload) {
-    const foundActionIndex = this.actions.findIndex((action) => action.txn === txn);
-    const foundAction = foundActionIndex !== -1 ? this.actions[foundActionIndex] : null;
+    const foundActionIndex = this.actions.findIndex(
+      (action) => action.txn === txn,
+    );
+    const foundAction =
+      foundActionIndex !== -1 ? this.actions[foundActionIndex] : null;
     if (!foundAction) {
       console.warn("pkgController: ACTION NOT FOUND.", { txn });
       return;
@@ -167,7 +258,7 @@ class PkgController {
         break;
       case "PUP-ACTION":
         // TODO.
-        if (foundAction.pupId === '--') {
+        if (foundAction.pupId === "--") {
           return;
         }
         this.updatePupModel(foundAction.pupId, payload.update);
@@ -186,31 +277,59 @@ class PkgController {
   }
 
   updatePupStatsModel(pupId, newPupStatsData) {
-    if (this.installedPackageIndex[pupId]) {      
-      this.installedPackageIndex[pupId].stats = newPupStatsData;
-      this.installedPackageIndex[pupId].computed = computeVals(pupId, this.installedPackageIndex[pupId], newPupStatsData);
+    if (this.stateIndex[newPupStatsData.id]) {
+      // Update index data in place.
+      this.statsIndex[newPupStatsData.id] = newPupStatsData
+
+      // Update pup array data in place
+      const foundIndex = this.pups.findIndex(p => p.state.id === newPupStatsData.id)
+      if (foundIndex >= 0) {
+        this.pups[foundIndex].stats = newPupStatsData;
+        this.pups[foundIndex].computed = this.determineCalculatedVals(this.pups[foundIndex])
+      }
+
+      // Notify subscribers of change
       this.notify();
+
+    } else {
+      // Not handled.  Pup stats data only updated if pup is in memory.
+      // Todo. Reconsider this assumption as needed.
     }
   }
 
   updatePupModel(pupId, newPupStateData) {
-
     if (!isValidState(newPupStateData)) {
-      console.warn('Validation error. Invalid pupState structure')
+      console.warn("Validation error. Invalid pupState structure");
       return;
     }
 
-    const existingStats = this.installedPackageIndex[pupId]?.stats || {};
-    this.installedPackageIndex[pupId] = toEnrichedInstalledPup(pupId, newPupStateData, existingStats);
-    
-    const foundPkgIndex = this.installedPackages.findIndex(installedPkg => installedPkg.id === newPupStateData.id)
-    if (foundPkgIndex !== -1) {
-      this.installedPackages[foundPkgIndex] = this.installedPackageIndex[pupId];
+    const { pup, index } = this.getPupMaster({ pupId, lookupType: "byStatePupId" });
+
+    if (pup) {
+      this.stateIndex[newPupStateData.id] = newPupStateData
+
+      // Update pup array data in place
+      this.pups[index] = {
+        ...this.pups[index],
+        state: newPupStateData,
+        computed: this.determineCalculatedVals(this.pups[index])
+      }
     } else {
-      // Pup not yet present on available array. Push it to array
-      this.installedPackages.push(this.installedPackageIndex[pupId]);
+      // When receiving a pupState event for a pup NOT found in the stateIndex
+      // We add it as a new entry.  This is likely a record for a newly installed pup
+      // The user has clicked "install", and the client has received a pup event before
+      // the user has called /bootstrap.
+      let pup = {
+        computed: null,
+        def: this.sourcesIndex[newPupStateData.source.id]?.pups[newPupStateData.manifest.meta.name] || null,
+        state: newPupStateData,
+        stats: this.statsIndex[newPupStateData.id] || null,
+      }
+      pup.computed = this.determineCalculatedVals(pup);
+      this.pups.push(pup)
     }
 
+    // Notify subscribers of change
     this.notify();
   }
 
@@ -260,9 +379,11 @@ class PkgController {
     const timeoutMs = 15000; // 15 seconds
 
     // Make a network call
-    const res = await pickAndPerformPupAction(pupId, action, body).catch((err) => {
-      console.error(err);
-    });
+    const res = await pickAndPerformPupAction(pupId, action, body).catch(
+      (err) => {
+        console.error(err);
+      },
+    );
 
     if (!res || res.error) {
       callbacks.onError({
@@ -289,20 +410,25 @@ class PkgController {
       this.actions.forEach((a) => {
         if (!a.expireAt) return;
 
-        if (Date.now() > a.expireAt && typeof a.callbacks.onTimeout === "function") {
+        if (
+          Date.now() > a.expireAt &&
+          typeof a.callbacks.onTimeout === "function"
+        ) {
           try {
-            const registeredActionIndex = this.actions.findIndex((b) => b.id === a.id);
+            const registeredActionIndex = this.actions.findIndex(
+              (b) => b.id === a.id,
+            );
             this.actions.splice(registeredActionIndex, 1);
             a.callbacks.onTimeout();
-          } catch(err) {
-            console.warn('registered onTimeout fn for txn threw an error when called');
+          } catch (err) {
+            console.warn(
+              "registered onTimeout fn for txn threw an error when called",
+            );
           }
         }
-
-      })
+      });
     }, 1000);
   }
-
 }
 
 // Instance holder
@@ -323,7 +449,7 @@ function toArray(object) {
 
 function isValidState(pupState) {
   // TODO. PupState validity check
-  return !!(pupState && pupState.manifest)
+  return !!(pupState && pupState.manifest);
 }
 
 function toObject(array) {
@@ -372,15 +498,15 @@ function determineStatusId(state, stats) {
   const status = stats?.status;
   const flags = {
     needs_deps: state?.needs_deps,
-    needs_config: state?.needs_config
-  }
+    needs_config: state?.needs_config,
+  };
 
   if (installation === "uninstalling") {
-    return { id: "uninstalling", label: "Uninstalling" }
+    return { id: "uninstalling", label: "Uninstalling" };
   }
 
   if (installation === "uninstalled") {
-    return { id: "uninstalled", label: "Uninstalled" }
+    return { id: "uninstalled", label: "Uninstalled" };
   }
 
   if (flags.needs_deps) {
@@ -408,100 +534,4 @@ function determineStatusId(state, stats) {
   }
 
   return { id: "unknown", label: "unknown" };
-}
-
-// Extend Array prototype (for toObject convenience method)
-Array.prototype.toObject = function(options = {}) {
-  const key = options.key || 'id';
-  return this.reduce((obj, item) => {
-    if (item && typeof item === 'object' && key in item) {
-      obj[item[key]] = item;
-    }
-    return obj;
-  }, {});
-};
-
-function computeVals(pupId, pupState, pupStats) {
-  const urlEncodedPupName = encodeURIComponent(pupState.manifest.meta.name);
-  const urlEncodedSourceId = encodeURIComponent(pupState.source.id);
-
-  // const urlEncodedPupame = encodeURIComponent(pupState.manifest.meta.name.replaceAll(' ', '-')).toLowerCase();
-  // const urlEncodedSourceName = encodeURIComponent(pupState.source.name.replaceAll(' ', '-')).toLowerCase();
-  const status = determineStatusId(pupState, pupStats);
-  const installation = determineInstallationId(pupState);
-
-  return {
-    url: {
-      gui: `/explore/${pupId}/${urlEncodedPupName}/ui`,
-      library: `/pups/${pupId}/${urlEncodedPupName}`,
-      store: `/explore/${urlEncodedSourceId}/${urlEncodedPupName}`,
-    },
-    statusId: status.id,
-    statusLabel: status.label,
-    installationId: installation.id,
-    installationLabel: installation.label
-  }
-}
-
-function toEnrichedInstalledPup(pupId, pupState, pupStats) {
-  return {
-    ...pupState,
-    stats: pupStats,
-    computed: computeVals(pupId, pupState, pupStats)
-  }
-}
-
-function toFlattenedAvailablePupsArray(sources) {
-  const pupsArray = [];
-
-  for (const [sourceId, sourceData] of Object.entries(sources)) {
-    for (const [pupName, pupData] of Object.entries(sourceData.pups)) {
-
-      const versions = Object.entries(pupData.versions).map(([version, versionData]) => ({
-        version,
-        ...versionData
-      }));
-
-
-      const installedVersionNumber = pupData.installedVersion;
-      const versionLatest = pupData.latestVersion && versions.find(v => v.version === pupData.latestVersion) || {}
-
-      const versionInstalled = pupData.isInstalled && versions.find(v => v.version === installedVersionNumber) || {}
-      const versionOutdated = pupData.isInstalled && pupData.latestVersion !== pupData.installedVersion;
-
-      // COMPUTED
-      const status = determineStatusId({});
-      const installation = determineInstallationId(pupData);
-      // const urlEncodedSourceName = encodeURIComponent(sourceName.replaceAll(' ', '-')).toLowerCase();
-      // const urlEncodedPupName = encodeURIComponent(pupName.replaceAll(' ', '-')).toLowerCase();
-      const urlEncodedSourceId = encodeURIComponent(sourceId);
-      const urlEncodedPupName = encodeURIComponent(pupName);
-
-      const installedId = pupData.installedId;
-
-      const pup = {
-        id: pupName,
-        urlId: urlEncodedPupName,
-        source: { id: sourceId, lastUpdated: sourceData.lastUpdated },
-        ...pupData,
-        versionOutdated,
-        versionInstalled,
-        versionLatest,
-        versions,
-        computed: {
-          url: {
-            store: `/explore/${urlEncodedSourceId}/${urlEncodedPupName}`,
-            library: `/pups/${installedId}/${urlEncodedPupName}`,
-          },
-          statusId: status.id,
-          statusLabel: status.label,
-          installationId: installation.id,
-          installationLabel: installation.label
-        }
-      };
-      pupsArray.push(pup);
-    }
-  }
-
-  return pupsArray;
 }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -303,17 +303,21 @@ class PkgController {
       return;
     }
 
-    const { pup, index } = this.getPupMaster({ pupId, lookupType: "byStatePupId" });
+    const n = newPupStateData
+    const { pup, index } = this.getPupMaster({ pupId: n.id, sourceId: n.source.id, pupName: n.manifest.meta.name });
 
     if (pup) {
       this.stateIndex[newPupStateData.id] = newPupStateData
 
       // Update pup array data in place
-      this.pups[index] = {
+      let updated = {
         ...this.pups[index],
         state: newPupStateData,
-        computed: this.determineCalculatedVals(this.pups[index])
       }
+
+      updated.computed = this.determineCalculatedVals(updated)
+
+      this.pups[index] = updated
     } else {
       // When receiving a pupState event for a pup NOT found in the stateIndex
       // We add it as a new entry.  This is likely a record for a newly installed pup
@@ -326,6 +330,8 @@ class PkgController {
         stats: this.statsIndex[newPupStateData.id] || null,
       }
       pup.computed = this.determineCalculatedVals(pup);
+
+      this.stateIndex[pup.state.id] = newPupStateData;
       this.pups.push(pup)
     }
 

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -2,7 +2,7 @@ import WebSocketClient from "/api/sockets.js";
 import { store } from "/state/store.js";
 import { pkgController } from "/controllers/package/index.js";
 import { asyncTimeout } from "/utils/timeout.js";
-import { performMockCycle, c1, c4, c5, installEvent } from "/api/mocks/pup-state-cycle.js";
+import { performMockCycle, c1, c4, c5, mockInstallEvent } from "/api/mocks/pup-state-cycle.js";
 import { isUnauthedRoute } from "/utils/url-utils.js";
 
 async function mockedMainChannelRunner(onMessageCallback) {

--- a/src/controllers/sockets/main-channel.js
+++ b/src/controllers/sockets/main-channel.js
@@ -2,7 +2,7 @@ import WebSocketClient from "/api/sockets.js";
 import { store } from "/state/store.js";
 import { pkgController } from "/controllers/package/index.js";
 import { asyncTimeout } from "/utils/timeout.js";
-import { performMockCycle, c1, c4, c5 } from "/api/mocks/pup-state-cycle.js";
+import { performMockCycle, c1, c4, c5, installEvent } from "/api/mocks/pup-state-cycle.js";
 import { isUnauthedRoute } from "/utils/url-utils.js";
 
 async function mockedMainChannelRunner(onMessageCallback) {
@@ -14,6 +14,14 @@ async function mockedMainChannelRunner(onMessageCallback) {
       };
       onMessageCallback({ data: JSON.stringify(mockData) });
     }, 2000);
+  }
+
+  if (store.networkContext.demoInstallPup) {
+    setTimeout(() => {
+      onMessageCallback({
+        data: JSON.stringify(installEvent)
+      })
+    }, 3000)
   }
 
   if (store.networkContext.demoPupLifecycle) {

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -52,12 +52,15 @@ class PupPage extends LitElement {
     this._HARDCODED_UNINSTALL_WAIT_TIME = 0;
   }
 
+  getPup() {
+    return this.pkgController.getPupMaster({ 
+      pupId: this.context.store.pupContext.state.id,
+      lookupType: "byStatePupId"
+    }).pup
+  }
+
   connectedCallback() {
     super.connectedCallback();
-    // Observers with a pupId will be requested to
-    // update when state for that pup changes
-    // this.pupId = this.context.store.pupContext.id;
-    // this.pupEnabled = this.pkgController.getPup(this.pupId)?.enabled
     this.pkgController.addObserver(this);
   }
 
@@ -138,7 +141,7 @@ class PupPage extends LitElement {
   }
 
   async handleStartStop(e) {
-    const pupId = this.context.store.pupContext.id
+    const pupId = this.context.store.pupContext.state.id
     this.inflight_startstop = true;
     this.pupEnabled = e.target.checked;
     this.requestUpdate();
@@ -153,7 +156,7 @@ class PupPage extends LitElement {
   }
 
   async handleUninstall(e) {
-    const pupId = this.context.store.pupContext.id
+    const pupId = this.context.store.pupContext.state.id
     this.pupEnabled = false;
     this.inflight_uninstall = true;
     this.requestUpdate();
@@ -212,11 +215,11 @@ class PupPage extends LitElement {
     }
 
     const path = this.context.store?.appContext?.path || [];
-    const pkg = this.pkgController.getPup(pupContext.id);
+    const pkg = this.getPup();
 
     if (!pkg) return;
 
-    const hasChecks = (pkg?.manifest?.checks || []).length > 0;
+    const hasChecks = (pkg.state.manifest?.checks || []).length > 0;
 
     let labels = pkg?.computed || {}
     let isInstallationLoadingStatus =  ["uninstalling", "purging"].includes(labels.installationId);
@@ -257,11 +260,11 @@ class PupPage extends LitElement {
     const renderMenu = () => html`
       <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
         Enable or disable this Pup
-        <sl-switch slot="suffix" ?checked=${!disableActions && pkg.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight_startstop || labels.installationId !== "ready"}></sl-switch>
+        <sl-switch slot="suffix" ?checked=${!disableActions && pkg.state.enabled} @sl-input=${this.handleStartStop} ?disabled=${this.inflight_startstop || labels.installationId !== "ready"}></sl-switch>
       </action-row>
 
       <action-row prefix="gear" name="configure" label="Configure" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>
-        Customize ${pkg.manifest.package}
+        Customize ${pkg.state.manifest.meta.name}
       </action-row>
 
       <!--action-row prefix="archive-fill" name="properties" label="Properties" .trigger=${this.handleMenuClick} ?disabled=${disableActions}>

--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -13,7 +13,7 @@ export function openDeps() {
 
 export async function handlePurgeFunction() {
   this.inflight_purge = true;
-  const pupId = this.context.store?.pupContext.id
+  const pupId = this.getPup().state.id
   this.requestUpdate();
 
   const callbacks = {
@@ -36,14 +36,13 @@ export async function handlePurgeFunction() {
 }
 
 export function renderActions(labels) {
-  const pupContext = this.context.store?.pupContext
-  const pkg = this.pkgController.getPup(pupContext.id);
+  const pkg = this.getPup();
   const { installationId, statusId, statusLabel } = labels
 
   const hasButtons =
     ["needs_deps", "needs_config"].includes(statusId)
     || ["uninstalled"].includes(installationId)
-    || pkg.manifest.gui;
+    || pkg.state.manifest?.gui;
 
   const styles = css`
     .action-wrap {
@@ -88,12 +87,12 @@ export function renderActions(labels) {
       ` : nothing }
 
 
-      ${pkg.manifest.gui ? html`
+      ${pkg.state.manifest?.gui ? html`
         <div style="display: flex; align-items: center;">
           ${statusId === 'needs_config' || statusId === 'needs_deps' ? html`
           <sl-divider class="show-only-wide" vertical style="height: 1.5em; margin-left: 0.1em;"></sl-divider>
           `: nothing}
-          <sl-button size="large" variant="warning" href="${pkg.computed.url.gui}"} ?disabled="${installationId !== "ready" }">
+          <sl-button size="large" variant="warning" href="${pkg.computed.guiURL}"} ?disabled="${installationId !== "ready" }">
             <sl-icon slot="prefix" name="stars"></sl-icon>
             Launch UI
           </sl-button>

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -5,12 +5,11 @@ import {
 } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderDialog() {
-  const pupContext = this.context.store?.pupContext
-  const pkg = this.pkgController.getPup(pupContext.id);
+  const pkg = this.getPup();
   const { statusId } = pkg.computed
   const readmeEl = html`<div style="padding: 1em; text-align: center;"> Such empty. This pup does not provide a README.</div>`;
-  const depsEl = pkg.manifest?.deps?.pups?.length > 0 
-    ? pkg.manifest.deps.pups.map((dep) => html`
+  const depsEl = pkg.state.manifest?.deps?.pups?.length > 0 
+    ? pkg.state.manifest.deps.pups.map((dep) => html`
       <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
         ${dep.condition}
       </action-row>`)
@@ -18,22 +17,22 @@ export function renderDialog() {
   `;
 
   const preventUninstallEl = html`
-    <p>Cannot uninstall a running Pup.<br/>Please disable ${pkg.manifest.meta.name } and try again.</p>
+    <p>Cannot uninstall a running Pup.<br/>Please disable ${pkg.state.manifest.meta.name } and try again.</p>
     <sl-button slot="footer" variant="primary" @click=${this.clearDialog}>Dismiss</sl-button>
     <style>p:first-of-type { margin-top: 0px; }</style>
   `
 
   const uninstallEl = html`
-    <p>Are you sure you want to uninstall ${pkg.manifest.meta.name}?</p>
-    <sl-input placeholder="Type '${pkg.manifest.meta.name}' to confirm" @sl-input=${(e) => this._confirmedName = e.target.value }></sl-input>
-    <sl-button slot="footer" variant="danger" @click=${this.handleUninstall} ?loading=${this.inflight_uninstall} ?disabled=${this.inflight_uninstall || this._confirmedName !== pkg.manifest.meta.name}>Uninstall</sl-button>
+    <p>Are you sure you want to uninstall ${pkg.state.manifest.meta.name}?</p>
+    <sl-input placeholder="Type '${pkg.state.manifest.meta.name}' to confirm" @sl-input=${(e) => this._confirmedName = e.target.value }></sl-input>
+    <sl-button slot="footer" variant="danger" @click=${this.handleUninstall} ?loading=${this.inflight_uninstall} ?disabled=${this.inflight_uninstall || this._confirmedName !== pkg.state.manifest.meta.name}>Uninstall</sl-button>
     <style>p:first-of-type { margin-top: 0px; }</style>
   `;
 
   const configEl = html`
     <dynamic-form
-      .values=${pkg?.config}
-      .fields=${pkg?.manifest?.config}
+      .values=${pkg?.state.config}
+      .fields=${pkg?.state.manifest?.config}
       .onSubmit=${this.submitConfig}
       requireCommit
       markModifiedFields

--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -8,8 +8,8 @@ import { bindToClass } from '/utils/class-bind.js'
 import * as renderMethods from './renders/index.js';
 
 const initialSort = (a, b) => {
-  if (a.manifest.package < b.manifest.package) { return -1; }
-  if (a.manifest.package > b.manifest.package) { return 1; }
+  if (a.state.manifest.package < b.state.manifest.package) { return -1; }
+  if (a.state.manifest.package > b.state.manifest.package) { return 1; }
   return 0;
 }
 
@@ -104,7 +104,7 @@ class LibraryView extends LitElement {
     try {
       const res = await getBootstrapV2()
       this.pkgController.setData(res);
-      this.installedList.setData(this.pkgController.installedPackages);
+      this.installedList.setData(this.pkgController.pups.filter(p => p.state));
     } catch (err) {
       console.error(err);
       this.fetchError = true;

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -61,16 +61,17 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('installed') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.installedList.getCurrentPageData(), (pkg) => `${pkg.id}-${pkg.version}`, (pkg) => html`
+        ${repeat(this.installedList.getCurrentPageData(), (pkg) => `${pkg.state.id}-${pkg.state.version}`, (pkg) => html`
           <pup-card
             icon="box"
-            pupId=${pkg.id}
-            pupName=${pkg.manifest.meta.name}
-            version=${pkg.version}
-            status=${pkg.computed.statusLabel}
-            href=${pkg.computed.url.library}
-            gref=${pkg.computed.url.ui}
-            ?hasGui=${!!pkg.manifest.gui} // TOMOO
+            pupId=${pkg.state.id}
+            pupName=${pkg.state.manifest.meta.name}
+            version=${pkg.state.version}
+            status="TODO"
+            _status=${pkg.computed.statusLabel}
+            href=${pkg.computed.libraryURL}
+            gref=${pkg.computed.pupURL}
+            ?hasGui=${false}
           ></pup-card>
         `)}
       </div>

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -67,8 +67,7 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
             pupId=${pkg.state.id}
             pupName=${pkg.state.manifest.meta.name}
             version=${pkg.state.version}
-            status="TODO"
-            _status=${pkg.computed.statusLabel}
+            status=${pkg.computed.statusLabel}
             href=${pkg.computed.libraryURL}
             gref=${pkg.computed.pupURL}
             ?hasGui=${false}

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -40,13 +40,16 @@ class PupInstallPage extends LitElement {
     this.inflight = false;
   }
 
+  getPup() {
+    return this.pkgController.getPupMaster({ 
+      sourceId: this.context.store.pupContext.def.source.id,
+      pupName: this.context.store.pupContext.def.key,
+      lookupType: "byDefSourceIdAndPupName"
+    }).pup
+  }
+
   connectedCallback() {
     super.connectedCallback();
-    // this.pupId = this.context.store.pupDefinitionContext.id;
-    // this.pkg = this.pkgController.getPupDefinition(
-    //   this.context.store.pupDefinitionContext.source.id,
-    //   this.context.store.pupDefinitionContext.id
-    // );
     this.pkgController.addObserver(this);
   }
 
@@ -74,9 +77,9 @@ class PupInstallPage extends LitElement {
   };
 
   render() {
-    const pupDefinitionContext = this.context.store?.pupDefinitionContext
+    const pupContext = this.context.store?.pupContext
 
-    if (!pupDefinitionContext.ready) {
+    if (!pupContext.ready) {
       return html`
       <div id="PageWrapper" class="wrapper">
         <section>
@@ -88,7 +91,7 @@ class PupInstallPage extends LitElement {
       </div>`
     }
 
-    if (pupDefinitionContext.result !== 200) {
+    if (pupContext.result !== 200) {
       return html`
       <div id="PageWrapper" class="wrapper">
         <section>
@@ -102,12 +105,12 @@ class PupInstallPage extends LitElement {
     }
 
     const path = this.context.store?.appContext?.path || [];
-    const pkg = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
+    const pkg = this.getPup();
 
     if (!pkg) return;
 
-    const { statusId, statusLabel, installationId, installationLabel } = pkg.computed
-    const hasDependencies = (pkg?.manifest?.deps?.pups || []).length > 0
+    const { statusId, statusLabel, installationId, installationLabel } = pkg?.computed
+    // const hasDependencies = (pkg?.state.manifest?.deps?.pups || []).length > 0
     const popover_page = path[1];
 
     const wrapperClasses = classMap({
@@ -115,13 +118,13 @@ class PupInstallPage extends LitElement {
       installed: ["ready", "unready"].includes(installationId),
     });
 
-    const renderDependancyList = () => {
-      return pkg.manifest.deps.pups.map((dep) => html`
-        <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
-          ${dep.condition}
-        </action-row>
-      `);
-    };
+    // const renderDependancyList = () => {
+    //   return pkg.state.manifest.deps.pups.map((dep) => html`
+    //     <action-row prefix="box-seam" name=${dep.id} label=${dep.name} href=${`/explore/${dep.id}/${dep.name}`}>
+    //       ${dep.condition}
+    //     </action-row>
+    //   `);
+    // };
 
     return html`
       <div id="PageWrapper" class="${wrapperClasses}" ?data-freeze=${popover_page}>
@@ -134,12 +137,12 @@ class PupInstallPage extends LitElement {
           <div class="section-title">
             <h3>Description</h3>
             <reveal-row>
-              <p>${pkg?.versionLatest?.meta?.shortDescription}<br/>${pkg?.versionLatest?.meta?.longDescription}</p>
+              <p>${pkg.def.versions[pkg.def.latestVersion].meta.shortDescription}<br/>${pkg?.versionLatest?.meta?.longDescription}</p>
             </reveal-row>
           </div>
         </section>
 
-        ${hasDependencies ? html`
+        ${false && hasDependencies ? html`
           <section>
             <div class="section-title">
               <h3>Dependencies</h3>

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -16,14 +16,13 @@ export function renderActions() {
   // const statusId = pkg?.computed?.statusId;
   // const statusLabel = pkg?.computed?.statusLabel;
 
-  const pupDefinitionContext = this.context.store?.pupDefinitionContext
-  const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
-  const pkg = this.pkgController.getPupByDefinitionData(pupDefinitionContext?.source?.id, pupDefinitionContext?.id)
+  const pupContext = this.context.store?.pupContext;
+  const pkg = this.getPup();
 
-  const installationId = pkg?.computed?.installationId;
-  const installationLabel = pkg?.computed?.installationLabel;
+  const installationId = pkg.computed.installationId;
+  const installationLabel = pkg.computed.installationLabel;
 
-  const isInstalled = def.isInstalled || installationId === "ready"
+  const isInstalled = pkg.computed.isInstalled;
   const isLoadingStatus = ["installing"].includes(installationId);
 
   const styles = css`
@@ -38,51 +37,76 @@ export function renderActions() {
         min-width: 180px;
       }
     }
-  `
+  `;
 
   return html`
     <div class="action-wrap">
-
-      ${!isInstalled && installationId !== "installing" ? html`
-        <sl-button variant="warning" size="large"
-          @click=${this.handleInstall}
-          ?disabled=${this.inflight}
-          ?loading=${this.inflight}>
-          Such Install
-        </sl-button>
-      ` : nothing }
-
-      ${!isInstalled && installationId === "installing" ? html`
-        <sl-button variant="warning" size="large" disabled>
-          Installing <sl-spinner slot="suffix" style="--indicator-color:#222"></sl-spinner>
-        </sl-button>
-      ` : nothing }
-
-      ${isInstalled ? html`
-        <sl-button variant="primary" size="large" href="${pkg.computed.url.library}">
-          Manage
-        </sl-button>
-      ` : nothing }
-
+      ${!isInstalled && installationId !== "installing"
+        ? html`
+            <sl-button
+              variant="warning"
+              size="large"
+              @click=${this.handleInstall}
+              ?disabled=${this.inflight}
+              ?loading=${this.inflight}
+            >
+              Such Install
+            </sl-button>
+          `
+        : nothing}
+      ${isInstalled && installationId === "installing"
+        ? html`
+            <sl-button variant="warning" size="large" disabled>
+              Installing
+              <sl-spinner
+                slot="suffix"
+                style="--indicator-color:#222"
+              ></sl-spinner>
+            </sl-button>
+          `
+        : nothing}
+      ${isInstalled && installationId !== "installing"
+        ? html`
+            <sl-button
+              variant="primary"
+              size="large"
+              href="${pkg.computed.libraryURL}"
+            >
+              Manage
+            </sl-button>
+          `
+        : nothing}
     </div>
-    <style>${styles}</style>
-  `
-};
-
-export async function handleInstall() {
-  const pupDefinitionContext = this.context.store?.pupDefinitionContext
-  const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
-  this.inflight = true;
-  const callbacks = {
-    onSuccess: () => { this.inflight = false; },
-    onError: () => { console.log('Txn reported an error'); this.inflight = false; },
-    onTimeout: () => { console.log('Slow txn, no repsonse within ~30 seconds (install)'); this.inflight = false; }
-  }
-  const body = {
-    sourceId: def.source.id,
-    pupName: def.versionLatest.meta.name,
-    pupVersion: def.versionLatest.meta.version
-  }
-  await this.pkgController.requestPupAction('--', 'install', callbacks, body);
+    <style>
+      ${styles}
+    </style>
+  `;
 }
 
+export async function handleInstall() {
+  const pupContext = this.context.store.pupContext;
+  const pkg = this.getPup();
+  this.inflight = true;
+  const callbacks = {
+    onSuccess: () => {
+      this.inflight = false;
+    },
+    onError: () => {
+      console.log("Txn reported an error");
+      this.inflight = false;
+    },
+    onTimeout: () => {
+      console.log("Slow txn, no repsonse within ~30 seconds (install)");
+      this.inflight = false;
+    },
+  };
+
+  const body = {
+    sourceId: pkg.def.source.id,
+    pupName: pkg.def.versions[pkg.def.latestVersion].meta.name,
+    pupVersion: pkg.def.latestVersion,
+  };
+
+  console.log("issuing install request: ", { ...body });
+  await this.pkgController.requestPupAction("--", "install", callbacks, body);
+}

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -107,6 +107,5 @@ export async function handleInstall() {
     pupVersion: pkg.def.latestVersion,
   };
 
-  console.log("issuing install request: ", { ...body });
   await this.pkgController.requestPupAction("--", "install", callbacks, body);
 }

--- a/src/pages/page-pup-store-listing/renders/dialog.js
+++ b/src/pages/page-pup-store-listing/renders/dialog.js
@@ -1,8 +1,8 @@
 import { html, choose, unsafeHTML } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderDialog() {
-  const pupDefinitionContext = this.context.store?.pupDefinitionContext
-  const pkg = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
+  const pupContext = this.context.store?.pupContext
+  const pkg = this.getPup();
   const readmeEl = html`<div style="padding: 1em; text-align: center;"> Such empty. This pup does not provide a README.</div>`;
 
   return html`

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -7,7 +7,7 @@ export function renderStatus() {
   const installationId = pkg?.computed?.installationId;
   const installationLabel = pkg?.computed?.installationLabel;
 
-  const isInstalled = pkg.computed.isInstalled;
+  const isInstalled = installationId === 'ready' && pkg.computed.isInstalled;
   const isLoadingStatus = ["installing"].includes(installationId);
 
   const normalisedLabel = () => {

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -1,14 +1,13 @@
 import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function renderStatus() {
-  const pupDefinitionContext = this.context.store?.pupDefinitionContext
-  const def = this.pkgController.getPupDefinition(pupDefinitionContext.source.id, pupDefinitionContext.id);
-  const pkg = this.pkgController.getPupByDefinitionData(pupDefinitionContext?.source?.id, pupDefinitionContext?.id)
+  const pupContext = this.context.store.pupContext
+  const pkg = this.getPup();
 
   const installationId = pkg?.computed?.installationId;
   const installationLabel = pkg?.computed?.installationLabel;
 
-  const isInstalled = def.isInstalled || installationId === "ready"
+  const isInstalled = pkg.computed.isInstalled;
   const isLoadingStatus = ["installing"].includes(installationId);
 
   const normalisedLabel = () => {
@@ -24,7 +23,7 @@ export function renderStatus() {
       <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
     </div>
     <div>
-      <span class="status-label">${def.versionLatest.meta.name}</span>
+      <span class="status-label">${pkg.def.versions[pkg.def.latestVersion].meta.name}</span>
       <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
     </div>
     <style>${styles}</style>

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -9,8 +9,8 @@ import '/components/common/paginator/paginator-ui.js';
 import '/components/common/page-banner.js';
 
 const initialSort = (a, b) => {
-  if (a.versionLatest.meta.name < b.versionLatest.meta.name) { return -1; }
-  if (a.versionLatest.meta.name > b.versionLatest.meta.name) { return 1; }
+  if (a?.def?.versions[a?.def?.versionLatest]?.meta?.name < b?.def?.versions[b?.def?.versionLatest]?.meta?.name) { return -1; }
+  if (a?.def?.versions[a?.def?.versionLatest] > b?.def?.versions[b?.def?.versionLatest]?.meta?.name) { return 1; }
   return 0;
 }
 
@@ -113,9 +113,9 @@ class StoreView extends LitElement {
     this.dispatchEvent(new CustomEvent('busy-start', {}));
 
     try {
-      const res = await getStoreListing()
-      this.pkgController.ingestAvailablePupDefs(res);
-      this.packageList.setData(this.pkgController.packageDefinitions);
+      const storeListingRes = await getStoreListing()
+      this.pkgController.setStoreData(storeListingRes);
+      this.packageList.setData(this.pkgController.pups);
     } catch (err) {
       console.error(err);
       this.fetchError = true;

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -10,7 +10,6 @@ var pupCardGrid = css`
 
 export function renderSectionHeader(ready) {
 
-
   return html`
 
     <!-- div class="actions">
@@ -52,15 +51,16 @@ export function renderSectionBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('packages') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.source.id}-${pkg.id}`, (pkg) => html`
+        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def.source.id}-${pkg.def.key}`, (pkg) => html`
           <pup-install-card
             icon="box"
-            pupId="${pkg.source.id}-${pkg.id}"
-            pupName=${pkg.versionLatest.meta.name}
-            version=${pkg.versionLatest.version}
-            short=${pkg.versionLatest.meta.descShort}
-            ?installed=${pkg.isInstalled}
-            href=${pkg.computed.url.store}
+            sourceId="${pkg.def.source.id}"
+            defKey="${pkg.def.key}"
+            pupName=${pkg.def.key}
+            version="${pkg.def.latestVersion}"
+            short="Its over 9000"
+            ?installed=${pkg.computed.isInstalled}
+            href=${pkg.computed.storeURL}
           ></pup-install-card>
         `)}
       </div>

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -1,4 +1,4 @@
-import { isAuthed, loadPup, loadPupDefinition, asPage, performLogout } from "./middleware.js"
+import { isAuthed, loadPup, asPage, performLogout } from "./middleware.js"
 
 export const routes = [
   {
@@ -34,7 +34,7 @@ export const routes = [
     before: [isAuthed, asPage]
   },
   {
-    path: "/pups/:pup/:name",
+    path: "/pups/:pupid/:pupname",
     component: "x-page-pup-library-listing",
     dynamicTitle: true,
     pageAction: "back",
@@ -58,16 +58,16 @@ export const routes = [
     before: [isAuthed, asPage],
   },
   {
-    path: "/explore/:source/:name",
+    path: "/explore/:sourceid/:pupname",
     component: "x-page-pup-store-listing",
     dynamicTitle: true,
     pageAction: "back",
     before: [isAuthed, asPage],
-    after: [loadPupDefinition],
+    after: [loadPup],
     animate: true,
   },
   {
-    path: "/explore/:pup/:name/ui",
+    path: "/explore/:pupid/:pupname/ui",
     component: "x-page-pup-iframe",
     dynamicTitle: true,
     pageAction: "close",

--- a/src/router/middleware.js
+++ b/src/router/middleware.js
@@ -5,54 +5,59 @@ import { getBootstrapV2 } from "/api/bootstrap/bootstrap.js";
 import { getStoreListing } from "/api/sources/sources.js";
 
 export async function loadPup(context, commands) {
-  const pupId = context.params.pup
-  if (!pupId) { return undefined; }
+  const pupId = context.params.pupid
+  const sourceId = context.params.sourceid
+  const pupName = decodeURIComponent(context.params.pupname)
+
+  // Bad params. 
+  // Must have one of pupId OR (sourceId AND pupName)
+  if (!pupId && (!sourceId || !pupName)) {
+    store.updateState({
+      pupContext: { ready: true, result: 400 },
+    });
+    return;
+  }
+
+  // What type of lookup to perform?
+  const lookupType = !!pupId ? "byStatePupId" : "byDefSourceIdAndPupName";
+  
+  // What type of bootstrapping to perform?
+  const isStoreListingPage = !!context.route.path.startsWith("/explore/:sourceid/:pupname");
+
   try {
-    // ensure bootstrap (temporary)
-    const res = await getBootstrapV2();
-    pkgController.setData(res);
 
-    const pup = pkgController.getPup(pupId);
+    // Attempt to get the pup from memory
+    let pup = pkgController.getPupMaster({ pupId, sourceId, pupName, lookupType }).pup;
 
-    if (!pup || !pup.manifest) {
-      throw new Error("manifest empty");
+    if (!pup) {
+      // Fetch bootstrap
+      pkgController.setData(await getBootstrapV2());
+      // Fetch Store listing (if on store type page);
+      isStoreListingPage && pkgController.setStoreData(await getStoreListing());
+      // Now attempt to get pup from memory
+      pup = pkgController.getPupMaster({ pupId, sourceId, pupName, lookupType }).pup;
     }
 
+    if (!pup) {
+      // Still no pup after bootstrapping. That's a proper 404.
+      console.warn("[404] loadPup middleware: pup not found in memory")
+      store.updateState({
+        pupContext: { ready: true, result: 404 },
+      });
+    }
+
+    // Return happy result
     store.updateState({
       pupContext: { ...pup, ready: true, result: 200 },
     });
 
   } catch (error) {
-    console.error("Error fetching manifest:", error);
-  }
-
-  return undefined
-}
-
-export async function loadPupDefinition(context, commands) {
-  const sourceId = decodeURIComponent(context.params.source);
-  const pupName = decodeURIComponent(context.params.name);
-  if (!sourceId || !pupName) { return undefined; }
-
-  try {
-    // ensure bootstrap (temporary)
-    const res = await getStoreListing();
-    pkgController.ingestAvailablePupDefs(res);
-    const pup = pkgController.getPupDefinition(sourceId, pupName);
-
-    if (!pup) {
-      throw new Error("missing pup definition");
-    }
-
+    console.warn("[500] loadPup middleware: failure.", error)
     store.updateState({
-      pupDefinitionContext: { ...pup, ready: true, result: 200 }
+      pupContext: { ready: true, result: 500 },
     });
 
-  } catch (error) {
-    console.error("Error fetching manifest:", error);
   }
-
-  return undefined
 }
 
 export function isAuthed(context, commands) {
@@ -70,7 +75,7 @@ export function performLogout(context, commands) {
 
 export function asPage(context, commands) {
   if (context.route.dynamicTitle) {
-    context.route.pageTitle = decodeURIComponent(context.params.name);
+    context.route.pageTitle = decodeURIComponent(context.params.pupname);
     context.route.pageAction = "back";
   }
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -1,7 +1,8 @@
 export class Router {
   constructor(outlet, options = {}) {
     this.routes = [];
-    this.hooks = [];
+    this.beforeHooks = [];
+    this.afterHooks = [];
     this.outlet = outlet;
     this.transitionDuration = options.transitionDuration || 300;
     this.currentTransition = null;
@@ -40,8 +41,12 @@ export class Router {
     });
   }
 
-  addHook(fn) {
-    this.hooks.push(fn);
+  addBeforeHook(fn) {
+    this.beforeHooks.push(fn);
+  }
+
+  addAfterHook(fn) {
+    this.afterHooks.push(fn);
   }
 
   go(path, replace = false) {
@@ -76,6 +81,10 @@ export class Router {
 
     const processRoute = async () => {
       try {
+        for (const func of this.beforeHooks) {
+          const commandResult = await func(context, commands);
+        }
+
         if (route.before) {
           for (const func of route.before) {
             const commandResult = await func(context, commands);
@@ -92,7 +101,7 @@ export class Router {
           }
         }
 
-        for (const func of this.hooks) {
+        for (const func of this.afterHooks) {
           const commandResult = await func(context, commands);
         }
       } catch (error) {

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -31,13 +31,12 @@ class Store {
       demoSystemPrompt: "",
     };
     this.pupContext = {
-      // Define pup state here
-      manifest: {},
-      state: {},
-      computed: {},
-    };
-    this.pupDefinitionContext = {
-      computed: {},
+      computed: null,
+      def: null,
+      state: null,
+      stats: null,
+      ready: false,
+      result: null
     };
     this.promptContext = {
       display: false,
@@ -139,9 +138,6 @@ class Store {
     }
     if (partialState.pupContext) {
       this.pupContext = { ...this.pupContext, ...partialState.pupContext };
-    }
-    if (partialState.pupDefinitionContext) {
-      this.pupDefinitionContext = { ...this.pupDefinitionContext, ...partialState.pupDefinitionContext };
     }
     if (partialState.promptContext) {
       this.promptContext = {


### PR DESCRIPTION
This PR is the overdue refactor of how pups are held in memory in dpanel, going from disorganised to organised.

Pups are now a ""mono object"" containing:
```
{ 
  state: <PupState>
  stats: <PupStats>
  def <StoreListingDefinition>
  computed: <VariousClientSideCalculatedVals>
}
```
  
Getting to this state is helpful and makes adopting the sources v2 and accomodating future change to API responses easier to manage.

### Demo

Part A
![pup-lifecycle-partA](https://github.com/user-attachments/assets/4a945e1e-83da-4073-b495-d6d5d14e4277)

Part B
![pup-lifecycle-partB](https://github.com/user-attachments/assets/2a3f540a-83e7-4f51-a133-347add18a12a)
