### PR TITLE
Feature - Add/Remove/Refresh sources

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -33,6 +33,10 @@ export default class ApiClient extends ReactiveClass {
     return this.request(path, { ...config, method: 'PUT', body: JSON.stringify(body) });
   }
 
+  async delete(path, body, config = {}) {
+    return this.request(path, { ...config, method: 'DELETE', body: JSON.stringify(body) });
+  }
+
   async request(path, config) {
     // Debug, if the dev has forceDelay, wait the delay time in seconds before making request
     if (this.networkContext.forceDelayInSeconds) {

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -26,18 +26,28 @@ export default class ApiClient extends ReactiveClass {
   }
 
   async post(path, body, config = {}) {
-    return this.request(path, { ...config, method: 'POST', body: JSON.stringify(body) });
+    return this.request(path, { ...config, method: 'POST', body });
   }
 
   async put(path, body, config = {}) {
-    return this.request(path, { ...config, method: 'PUT', body: JSON.stringify(body) });
+    return this.request(path, { ...config, method: 'PUT', body });
   }
 
   async delete(path, body, config = {}) {
-    return this.request(path, { ...config, method: 'DELETE', body: JSON.stringify(body) });
+    return this.request(path, { ...config, method: 'DELETE', body });
   }
 
   async request(path, config) {
+
+    // if config.body is an empty object, remove the property.
+    // this is to prevent the browser from sending an empty body to the server
+    // which is not what we want.
+    if (Object.keys(config.body || {}).length === 0) {
+      delete config.body;
+    } else {
+      config.body = JSON.stringify(config.body);
+    }
+
     // Debug, if the dev has forceDelay, wait the delay time in seconds before making request
     if (this.networkContext.forceDelayInSeconds) {
       await new Promise(resolve => setTimeout(resolve, this.networkContext.forceDelayInSeconds * 1000));
@@ -81,7 +91,7 @@ export default class ApiClient extends ReactiveClass {
 
     if (!response.ok) {
       console.warn('Unsuccessful respose', { status: response.status })
-      throw new Error('Fetching returned an unsuccessful response');
+      throw new Error(response.error || `Request failed with error code: ${response.status}`);
     }
 
     try {

--- a/src/api/sources/manage.js
+++ b/src/api/sources/manage.js
@@ -18,7 +18,7 @@ export const sourceAddMock = {
 const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
 export async function removeSource(sourceId) {
-  return client.delete(`/source/${sourceId}`, { mock: sourceRemovalMock });
+  return client.delete(`/source/${sourceId}`, null, { mock: sourceRemovalMock });
 }
 
 export async function addSource(location) {

--- a/src/api/sources/manage.js
+++ b/src/api/sources/manage.js
@@ -1,0 +1,26 @@
+import ApiClient from '/api/client.js';
+import { store } from '/state/store.js'
+
+export const sourceRemovalMock = {
+  name: '/source/:sourceid',
+  method: 'delete',
+  group: 'sources',
+  res: { success: true }
+}
+
+export const sourceAddMock = {
+  name: '/source/:sourceid',
+  method: 'put',
+  group: 'sources',
+  res: { success: true }
+}
+
+const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+
+export async function removeSource(sourceId) {
+  return client.delete(`/source/${sourceId}`, { mock: sourceRemovalMock });
+}
+
+export async function addSource(location) {
+  return client.put(`/source`, { location }, { mock: sourceAddMock });
+}

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -1,5 +1,6 @@
 import ApiClient from '/api/client.js';
-import { store } from '/state/store.js'
+import { store } from '/state/store.js';
+import { pkgController } from '/controllers/package/index.js';
 
 import { 
   storeListingMock
@@ -9,4 +10,8 @@ const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkConte
 
 export async function getStoreListing() {
   return client.get('/sources/store', { mock: storeListingMock });
+}
+
+export async function refreshStoreListing() {
+  return pkgController.setStoreData(await getStoreListing());
 }

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -8,10 +8,11 @@ import {
 
 const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
 
-export async function getStoreListing() {
-  return client.get('/sources/store', { mock: storeListingMock });
+export async function getStoreListing(shouldFlush = false) {
+  const url = shouldFlush ? '/sources/store?refresh=true' : '/sources/store';
+  return client.get(url, { mock: storeListingMock });
 }
 
-export async function refreshStoreListing() {
-  return pkgController.setStoreData(await getStoreListing());
+export async function refreshStoreListing(shouldFlush = false) {
+  return pkgController.setStoreData(await getStoreListing(shouldFlush));
 }

--- a/src/components/common/action-row/action-row.js
+++ b/src/components/common/action-row/action-row.js
@@ -185,7 +185,7 @@ class ActionRow extends LitElement {
 
         <div class="suffix-wrap" part="suffix">
           <slot name="suffix">
-            <sl-icon name="chevron-right"></sl-icon>
+            <sl-icon name="${this.suffix || "chevron-right"}"></sl-icon>
           </slot>
         </div>
       </div>

--- a/src/components/common/action-row/action-row.js
+++ b/src/components/common/action-row/action-row.js
@@ -85,7 +85,7 @@ class ActionRow extends LitElement {
       display: flex;
       flex-direction: row;
       width: 100%;
-      height: 62px;
+      height: var(--row-height, 62px);
       align-items: center;
     }
 
@@ -99,7 +99,7 @@ class ActionRow extends LitElement {
     }
 
     .body-wrap {
-      height: 62px;
+      height: var(--row-height,62px);
       padding-bottom: 2px;
       flex: 1 0 auto; /* Grow to fill the space, no shrink, basis auto */
       display: flex;
@@ -107,8 +107,10 @@ class ActionRow extends LitElement {
       justify-content: center;
       border-bottom: 1px solid #333;
       max-width: calc(100% - 80px);
+      gap: 0.25em;
 
       .label-wrap {
+        line-height: 1.1;
         font-weight: bold;
         white-space: nowrap;
         overflow: hidden;
@@ -124,8 +126,18 @@ class ActionRow extends LitElement {
         text-overflow: ellipsis;
       }
 
+      .more-wrap {
+        line-height: 1;
+        font-size: 0.9rem;
+        font-family: "Comic Neue";
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
       .label-wrap, 
-      .description-wrap {
+      .description-wrap,
+      .more-wrap  {
         flex-grow: 0;
         flex-shrink: 1;
         max-width: calc(100% - 10px);
@@ -180,6 +192,9 @@ class ActionRow extends LitElement {
           </div>
           <div class="description-wrap">
             <slot></slot>
+          </div>
+          <div class="more-wrap">
+            <slot name="more"></slot>
           </div>
         </div>
 

--- a/src/components/common/alert.js
+++ b/src/components/common/alert.js
@@ -7,8 +7,6 @@ export function createAlert(variant, message, icon = 'info-circle', duration = 0
       document.body.setAttribute('listener-on-sl-after-hide', true);
     }
 
-    console.log({ variant, message, icon, duration, action });
-
     const alert = document.createElement('sl-alert');
     alert.variant = variant;
     alert.closable = true;
@@ -67,15 +65,12 @@ function createMoreDetailDialog(messageEl, providedError) {
   dialog.classList.add("error-dialog");
   dialog.classList.add('above-toasts') // Dialogs usually sit below toasts in terms of z-index. This class styles them to sit above.
 
-  let error = new Error(providedError);
+  const error = (providedError instanceof Error)
+    ? providedError
+    : new Error(providedError);
 
-  if (providedError instanceof Error) {
-    error = providedError
-  }
-
-  if (providedError.error) {
-    error = new Error(providedError.error);
-  }
+  // Remove leading "Error:" if present
+  const errorMessage = error.message.replace(/^Error:\s*/, '');
 
   // Limit stack trace
   const maxLines = 4;
@@ -89,7 +84,7 @@ function createMoreDetailDialog(messageEl, providedError) {
   const content = document.createElement('div');
   content.innerHTML = `
   <pre style="text-wrap: wrap; font-size: var(--sl-font-size-small); padding: 1em; background: #333;">${messageEl}</pre>
-  <pre style="text-wrap: wrap; font-size: var(--sl-font-size-small); padding: 1em; background: #a300ff70; margin-bottom: 0;">${error}</pre>
+  <pre style="text-wrap: wrap; font-size: var(--sl-font-size-small); padding: 1em; background: #a300ff70; margin-bottom: 0;">${errorMessage}</pre>
   <pre style="font-size: var(--sl-font-size-x-small); padding: 1em; background: #c700ff21; overflow-x: scroll; margin-top: 0;">${error.stack}</pre>
   `
   dialog.appendChild(content);

--- a/src/components/common/alert.js
+++ b/src/components/common/alert.js
@@ -1,46 +1,56 @@
 import { html, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function createAlert(variant, message, icon = 'info-circle', duration = 0, action, errorDetail) {
-
-  if (!document.body.hasAttribute('listener-on-sl-after-hide')) {
-    document.body.addEventListener('sl-after-hide', closeErrorDialog);
-    document.body.setAttribute('listener-on-sl-after-hide', true);
-  }
-
-  const alert = document.createElement('sl-alert');
-  alert.variant = variant;
-  alert.closable = true;
-  if (duration) {
-    alert.duration = duration;
-  }
-
-  const iconEl = `<sl-icon name="${icon}" slot="icon"></sl-icon>`
-
-  const messageEl = Array.isArray(message)
-    ? `<strong>${escapeHtml(message[0])}</strong>` + message.slice(1).map(item => `<br>${escapeHtml(item)}`).join('')
-    : escapeHtml(message)
-
-  const actionEl = action ? `
-    <a class="more" no-intercept href="${`${window.location.href}?error=true`}">${action.text}</sl-button>
-    ` : nothing
-
-  alert.innerHTML = `
-    ${iconEl}
-    ${messageEl}
-    ${actionEl}
-  `
-
-  document.body.append(alert);
-
-  if (action) {
-    try {
-      const anchor = alert.querySelector("a.more")
-      anchor.addEventListener("click", (e) => { e.preventDefault(); createMoreDetailDialog(messageEl, errorDetail) })
-    } catch (err) {
-      console.error(err);
+  try {
+    if (!document.body.hasAttribute('listener-on-sl-after-hide')) {
+      document.body.addEventListener('sl-after-hide', closeErrorDialog);
+      document.body.setAttribute('listener-on-sl-after-hide', true);
     }
+
+    console.log({ variant, message, icon, duration, action });
+
+    const alert = document.createElement('sl-alert');
+    alert.variant = variant;
+    alert.closable = true;
+    if (duration) {
+      alert.duration = duration;
+    }
+
+    const iconEl = `<sl-icon name="${icon}" slot="icon"></sl-icon>`
+
+    const messageEl = Array.isArray(message)
+      ? `<strong>${escapeHtml(message[0])}</strong>` + message.slice(1).map(item => `<br>${escapeHtml(item)}`).join('')
+      : escapeHtml(message)
+
+    if (action) {
+      const actionEl = `<a class="more" no-intercept href="${`${window.location.href}?error=true`}">${action?.text}</a>`
+      alert.innerHTML = `
+        ${iconEl}
+        ${messageEl}
+        ${actionEl}
+      `  
+    } else {
+      alert.innerHTML = `
+        ${iconEl}
+        ${messageEl}
+      `
+    }
+
+    document.body.append(alert);
+
+    if (action) {
+      try {
+        const anchor = alert.querySelector("a.more")
+        anchor.addEventListener("click", (e) => { e.preventDefault(); createMoreDetailDialog(messageEl, errorDetail) })
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    alert.toast();
+  } catch (alertError) {
+    console.warn('Failed to produce alert', { ...arguments });
+    console.error(alertError)
   }
-  alert.toast();
 }
 
 // Utility function to escape HTML

--- a/src/components/views/action-manage-sources/index.js
+++ b/src/components/views/action-manage-sources/index.js
@@ -1,0 +1,198 @@
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { createAlert } from "/components/common/alert.js";
+import { asyncTimeout } from "/utils/timeout.js";
+import { pkgController } from "/controllers/package/index.js";
+import { addSource, removeSource } from "/api/sources/manage.js";
+
+export class SourceManagerView extends LitElement {
+
+  static get properties() {
+    return {
+      _ready: { type: Boolean },
+      _showSourceRemovalConfirmation: { type: Boolean },
+      _showAddSourceDialog: { type: Boolean },
+      _sourceRemovaInProgress: { type: Boolean },
+      _sources: { type: Object, state: true },
+      _selectedSourceId: { type: String },
+      _addSourceInputURL: { type: String },
+      _addSourceInProgress: { type: Boolean },
+    }
+  }
+
+  constructor() {
+    super();
+    this._ready = false;
+    this._sources = [];
+    
+    this._showSourceRemovalConfirmation = false;
+    this._showAddSourceDialog = false;
+    
+    this._sourceRemovaInProgress = false;
+    this._addSourceInProgress = false;
+    
+    this._selectedSourceId = null;
+    this._addSourceInputURL = "";
+  }
+
+  firstUpdated() {
+    this.fetchSources()
+  }
+
+  fetchSources() {
+    this._sources = pkgController.getSourceList()
+    setTimeout(() => { this._ready = true; }, 1000);
+  }
+
+  handleRemoveClick(sourceId) {
+    this._selectedSourceId = sourceId
+    this._showSourceRemovalConfirmation = true;
+  }
+
+  async handleRemovalConfirmClick() {
+    if (!this._selectedSourceId) {
+      console.warn('apparantely no source is selected')
+    }
+    this._sourceRemovaInProgress = true;
+    try {
+      await asyncTimeout(1000);
+      await removeSource(this._selectedSourceId);
+      createAlert("success", 'Source removed.', 'check-square', 2000);
+
+      // TODO better success handling
+      await asyncTimeout(2000);
+      window.location.reload();
+
+    } catch (err) {
+      console.log('ERROR', err);
+      const message = ["Source removal failed", "Please refresh your browser and try again"];
+      const action = { text: "View details" };
+      createAlert("danger", message, "emoji-frown", null, action, new Error(err));
+    } finally {
+      this._sourceRemovaInProgress = false;
+      this._selectedSourceId = null;
+    }
+  }
+
+  handleAddSourceClick() {
+    this._showAddSourceDialog = true;
+  }
+
+  async handleAddSourceSubmitClick() {
+    this._addSourceInProgress = true;
+    try {
+      await asyncTimeout(1000);
+      await addSource(this._addSourceInputURL);
+      createAlert("success", 'Source added.', 'check-square', 2000);
+
+      // TODO better success handling
+      await asyncTimeout(2000);
+      window.location.reload();
+
+    } catch (err) {
+      console.log('ERROR', err);
+      const message = ["Failed to add source.", "Please refresh your browser and try again"];
+      const action = { text: "View details" };
+      createAlert("danger", message, "emoji-frown", null, action, new Error(err));
+    } finally {
+      this._addSourceInProgress = false;
+    }
+  }
+
+  render() {
+
+    const renderSourceAction = (sourceId) => {
+      return html`
+        <div class="dropdown-selection-alt" slot="suffix">
+          <sl-dropdown>
+            <sl-button slot="trigger" caret></sl-button>
+            <sl-menu>
+              <sl-menu-item value="copy" @click=${() => this.handleRemoveClick(sourceId)}>Remove</sl-menu-item>
+            </sl-menu>
+          </sl-dropdown>
+        </div>
+      `
+    }
+
+    const renderAddSource = () => {
+      return html`
+        <sl-dialog ?open=${this._showAddSourceDialog} style="--width: 55vw" no-header>
+          
+          <sl-input
+            label="Enter source URL"
+            placeholder="Eg: https://github.com/SomeoneWeird/test-pups.git"
+            @sl-input=${(e) => this._addSourceInputURL = e.target.value }
+            >
+          </sl-input>
+
+          <div slot="footer">
+            <sl-button variant="text" @click=${() => this._showAddSourceDialog = false}>Cancel</sl-button>
+            <sl-button variant="primary" ?disabled=${!this._addSourceInputURL} ?loading=${this._addSourceInProgress} @click=${this.handleAddSourceSubmitClick}>
+              Add this source
+            </sl-button>
+          </div>
+          
+        </sl-dialog>
+      `
+    }
+
+    const renderRemovalConfirmation = () => {
+      return html`
+        <sl-dialog ?open=${this._showSourceRemovalConfirmation} style="--width: auto" no-header>
+          <div style="max-width: 320px;">
+            <h3>Are you sure?</h3>
+            You will no longer see pups from this source.
+          </div>
+          <div slot="footer">
+            <sl-button variant="text" @click=${() => this._showSourceRemovalConfirmation = false}>Cancel</sl-button>
+            <sl-button variant="danger" ?loading=${this._sourceRemovaInProgress} @click=${this.handleRemovalConfirmClick}>
+              Yes, delete this source
+              <sl-icon slot="suffix" name="trash3-fill"></sl-icon>
+            </sl-button>
+          </div>
+          
+        </sl-dialog>
+      `
+    }
+
+    return html`
+      <sl-dialog open label="Pup Sources" style="position: relative;">
+        
+        ${!this._ready ? html`
+          <div class="loader-overlay">
+            <sl-spinner style="font-size: 2rem; --indicator-color: #bbb;"></sl-spinner>
+          </div>
+        ` : nothing }
+        
+        ${this._ready ? html`
+
+          ${this._sources.map((s) => html`
+            <action-row label="${s.name}" prefix="git">
+              ${s.location}
+              ${renderSourceAction(s.sourceId)}
+            </action-row>`
+          )}
+        ` : nothing }
+
+        <div slot="footer">
+          <sl-button variant=primary ?disabled=${!this._ready} @click=${this.handleAddSourceClick}>
+            <sl-icon slot="prefix" name="plus-square-fill"></sl-icon>
+            Add Source
+          </sl-button>
+        </div>
+      ${renderRemovalConfirmation()}
+      ${renderAddSource()}
+      </sl-dialog>
+    `
+  }
+
+  static styles = css`
+    .loader-overlay {
+      height: 300px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `
+}
+
+customElements.define("action-manage-sources", SourceManagerView);

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -435,6 +435,21 @@ class PkgController {
       });
     }, 1000);
   }
+
+  getSourceList() {
+    if (!pkgController.sourcesIndex) {
+      return [];
+    }
+
+    return Object.entries(pkgController.sourcesIndex).map(([sourceId, sourceData]) => {
+      return {
+        sourceId: sourceId,
+        location: sourceData.location || "",
+        name: sourceData.name || "",
+        pupCount: Object.keys(sourceData.pups || {}).length
+      };
+    });
+  }
 }
 
 // Instance holder

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -55,6 +55,7 @@ class PkgController {
   handleBootstrapResponse(states, stats) {
     this.stateIndex = states;
     this.statsIndex = stats
+    this.pups = [];
 
     for (const [stateKey, stateData] of Object.entries(states)) {
 
@@ -444,17 +445,26 @@ class PkgController {
     }, 1000);
   }
 
+  getInstalledPupsForSource(sourceId) {
+    return this.pups.filter(p => p.state?.source?.id === sourceId);
+  }
+
   getSourceList() {
     if (!pkgController.sourcesIndex) {
       return [];
     }
 
     return Object.entries(pkgController.sourcesIndex).map(([sourceId, sourceData]) => {
+
+      const installedPupsForSource = pkgController.getInstalledPupsForSource(sourceId);
+      const installedCount = installedPupsForSource.length;
+
       return {
         sourceId: sourceId,
         location: sourceData.location || "",
         name: sourceData.name || "",
-        pupCount: Object.keys(sourceData.pups || {}).length
+        pupCount: Object.keys(sourceData.pups || {}).length,
+        installedCount
       };
     });
   }

--- a/src/controllers/package/index.js
+++ b/src/controllers/package/index.js
@@ -188,6 +188,14 @@ class PkgController {
     }
   }
 
+  removePupsBySourceId(sourceId) {
+    this.pups = this.pups.filter(p => p.def.source.id !== sourceId);
+    if (this.sourcesIndex[sourceId]) {
+      delete this.sourcesIndex[sourceId];
+    }
+    this.notify();
+  }
+
   registerAction(txn, callbacks, actionType, pupId, timeout) {
     if (!txn || !callbacks || !actionType || !pupId) {
       console.warn(

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -54,7 +54,7 @@ class PupPage extends LitElement {
 
   getPup() {
     return this.pkgController.getPupMaster({ 
-      pupId: this.context.store.pupContext.state.id,
+      pupId: this.context.store.pupContext?.state?.id,
       lookupType: "byStatePupId"
     }).pup
   }

--- a/src/pages/page-pup-library/index.js
+++ b/src/pages/page-pup-library/index.js
@@ -260,6 +260,8 @@ class LibraryView extends LitElement {
       border: dashed 1px var(--sl-color-neutral-200);
       border-radius: var(--sl-border-radius-medium);
       padding: var(--sl-spacing-x-large) var(--sl-spacing-medium);
+      font-family: 'Comic Neue', sans-serif;
+      text-align: center;
     }
   `
 }

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -54,7 +54,8 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
 
     ${ready && !hasItems('installed') ? html`
       <div class="empty">
-        Such empty.  No pups available in this repository.
+        Such empty.<br>
+        No pups available in this repository.
       </div>
       ` : nothing 
     }

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -42,8 +42,8 @@ class PupInstallPage extends LitElement {
 
   getPup() {
     return this.pkgController.getPupMaster({ 
-      sourceId: this.context.store.pupContext.def.source.id,
-      pupName: this.context.store.pupContext.def.key,
+      sourceId: this.context.store.pupContext?.def?.source?.id,
+      pupName: this.context.store.pupContext?.def?.key,
       lookupType: "byDefSourceIdAndPupName"
     }).pup
   }

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -65,7 +65,7 @@ class StoreView extends LitElement {
     this.addEventListener('pup-installed', this.handlePupInstalled.bind(this));
     this.addEventListener('forced-tab-show', this.handleForcedTabShow.bind(this));
     this.addEventListener('manage-sources-closed', this.handleManageSourcesClosed.bind(this));
-    this.addEventListener('source-removed', this.updatePups.bind(this));
+    this.addEventListener('source-change', this.updatePups.bind(this));
     this.fetchBootstrap();
   }
 
@@ -75,7 +75,7 @@ class StoreView extends LitElement {
     this.removeEventListener('pup-installed', this.handlePupInstalled.bind(this));
     this.removeEventListener('forced-tab-show', this.handleForcedTabShow.bind(this));
     this.removeEventListener('manage-sources-closed', this.handleManageSourcesClosed.bind(this));
-    this.removeEventListener('source-removed', this.updatePups.bind(this));
+    this.removeEventListener('source-change', this.updatePups.bind(this));
     this.pkgController.removeObserver(this);
     super.disconnectedCallback();
   }
@@ -143,7 +143,6 @@ class StoreView extends LitElement {
   }
 
   updatePups() {
-    console.log('CALLED');
     this.pups = this.pkgController.pups;
     this.requestUpdate('pups');
   }

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -7,6 +7,7 @@ import * as renderMethods from './renders/index.js';
 import '/components/views/card-pup-install/index.js'
 import '/components/common/paginator/paginator-ui.js';
 import '/components/common/page-banner.js';
+import '/components/views/action-manage-sources/index.js';
 
 const initialSort = (a, b) => {
   if (a?.def?.versions[a?.def?.versionLatest]?.meta?.name < b?.def?.versions[b?.def?.versionLatest]?.meta?.name) { return -1; }
@@ -21,7 +22,8 @@ class StoreView extends LitElement {
     fetchError: { type: Boolean },
     busy: { type: Boolean },
     inspectedPup: { type: String },
-    searchValue: { type: String }
+    searchValue: { type: String },
+    _showSourceManagementDialog: { type: Boolean }
   }
 
   constructor() {
@@ -33,6 +35,7 @@ class StoreView extends LitElement {
     this.itemsPerPage = 10;
     this.pkgController = pkgController;
     this.packageList = new PaginationController(this, undefined, this.itemsPerPage,{ initialSort });
+    this._showSourceManagementDialog = false;
 
     this.inspectedPup;
     this.showCategories = false;
@@ -150,6 +153,10 @@ class StoreView extends LitElement {
     this.packageList.setFilter((pkg) => pkg?.manifest?.package?.toLowerCase()?.includes(this.searchValue.toLowerCase()));
   }
 
+  handleManageSourcesClick() {
+    this._showSourceManagementDialog = true;
+  }
+
   render() {
     const ready = (
       !this.fetchLoading &&
@@ -170,12 +177,10 @@ class StoreView extends LitElement {
     return html`
       <page-banner title="Dogecoin" subtitle="Registry">
         Extend your Dogebox with Pups<br/>
-        <!--
-        <sl-button variant="text">
+        <sl-button variant="text" @click=${this.handleManageSourcesClick}>
           <sl-icon name="arrow-left-right" slot="prefix"></sl-icon>
-          Change Registry
+          Manage Sources
         </sl-button>
-        -->
       </page-banner>
 
       <div class="row search-wrap">
@@ -198,6 +203,10 @@ class StoreView extends LitElement {
         ? html`<sl-spinner style="--indicator-color:#777;"></sl-spinner>`
         : this.renderSectionBody(ready, SKELS, hasItems)
       }
+
+      ${this._showSourceManagementDialog ? html`
+        <action-manage-sources></action-manage-sources>
+      ` : nothing }
 
     `;
   }

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -11,8 +11,7 @@ var pupCardGrid = css`
 export function renderSectionHeader(ready) {
 
   return html`
-
-    <!-- div class="actions">
+    <div class="actions">
       <sl-dropdown>
         <sl-button slot="trigger" ?disabled=${this.busy}><sl-icon name="three-dots-vertical"></sl-icon></sl-button>
         <sl-menu @sl-select=${this.handleActionsMenuSelect}>
@@ -28,7 +27,7 @@ export function renderSectionHeader(ready) {
           <sl-menu-item value="refresh">Refresh</sl-menu-item>
         </sl-menu>
       </sl-dropdown>
-    </div -->
+    </div>
   `
 }
 
@@ -55,11 +54,11 @@ export function renderSectionBody(ready, SKELS, hasItems) {
         ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def.source.id}-${pkg.def.key}`, (pkg) => html`
           <pup-install-card
             icon="box"
-            sourceId="${pkg.def.source.id}"
-            defKey="${pkg.def.key}"
+            sourceId=${pkg.def.source.id}
+            defKey=${pkg.def.key}
             pupName=${pkg.def.key}
-            version="${pkg.def.latestVersion}"
-            short="Its over 9000"
+            version=${pkg.def.latestVersion}
+            short="${pkg.def.versions[pkg.def.latestVersion]?.meta?.shortDescription}"
             ?installed=${pkg.computed.isInstalled}
             href=${pkg.computed.storeURL}
           ></pup-install-card>

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -44,7 +44,8 @@ export function renderSectionBody(ready, SKELS, hasItems) {
 
     ${ready && !hasItems('packages') ? html`
       <div class="empty">
-        Such empty.  No pups available in this repository.
+        Such empty.<br>
+        No pups available in this repository.
       </div>
       ` : nothing 
     }


### PR DESCRIPTION
This PR adds a source management modal that allows the adding and removal of sources.

Includes:
- [X] success handling (shows prompt, refreshes list)
- [X] error handling (shows prompt)
- [X] source stats (pup count, install count)

Todo (subsequent PRS)
- [ ] Provide failure reasons (requires backend response changes)
- [ ] Add a refresh sources to the pup store page (will add later)

Add / Remove a source:
![add-remove-source](https://github.com/user-attachments/assets/653225c2-f91e-462f-b889-c5be99f37100)

Refresh all sources:
![refresh-all-sources](https://github.com/user-attachments/assets/f929ab2e-df01-45b6-87ef-50ae11481404)

Prevented from removing source with installed pups:
![image](https://github.com/user-attachments/assets/50feeffb-ff3a-4947-92a1-ab3047e17e40)
![image](https://github.com/user-attachments/assets/914a3c2e-b152-4555-9df1-468edbbaf337)
