### PR TITLE
Log Viewer - Pass it pupId

### DIFF
--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -17,7 +17,7 @@ class LogViewer extends LitElement {
   constructor() {
     super();
     this.logs = [];
-    this.pupId = store.pupContext.manifest.package;
+    this.pupId = "";
     this.isConnected = false;
     this.wsClient = null;
     this.follow = true;

--- a/src/components/views/x-log-viewer/index.js
+++ b/src/components/views/x-log-viewer/index.js
@@ -78,7 +78,7 @@ class LogViewer extends LitElement {
     }
 
     this.wsClient = new WebSocketClient(
-      `${store.networkContext.wsApiBaseUrl}/logs/${this.pupId}`,
+      `${store.networkContext.wsApiBaseUrl}/ws/log/${this.pupId}`,
       store.networkContext,
       mockedLogRunner
     );

--- a/src/pages/page-logs/index.js
+++ b/src/pages/page-logs/index.js
@@ -3,9 +3,20 @@ import "/components/views/x-log-viewer/index.js";
 
 class PageLogs extends LitElement {
 
+  // TODO - import router and get the pupId from the route params
+  // Rather than grabbing from URL.
+  getPupIdFromUrl(url) {
+    const parts = url.split('/');
+    const pupsIndex = parts.indexOf('pups');
+    if (pupsIndex !== -1 && parts.length > pupsIndex + 1) {
+      return parts[pupsIndex + 1];
+    }
+    return null;
+  }
+
   render() {
     return html`
-      <x-log-viewer></x-log-viewer>
+      <x-log-viewer pupId=${this.getPupIdFromUrl(window.location.pathname)}></x-log-viewer>
     `;
   }
 }

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -43,7 +43,7 @@ export const routes = [
     animate: true,
   },
   {
-    path: "/pups/:s/:name/logs",
+    path: "/pups/:pupid/:name/logs",
     component: "x-page-pup-logs",
     pageTitle: "Logs",
     pageAction: "close",


### PR DESCRIPTION
This PR ensures the log-viewer is passed a pupId.

This implementation is a quick fix, not the final state.

The final state will have our router pass pupIds to the pages they render OR easier and reliable access to the data on the pupContext