### PR TITLE
Feature: Stats

### DIFF
--- a/src/components/common/sparkline-chart/sparkline-chart-v2.js
+++ b/src/components/common/sparkline-chart/sparkline-chart-v2.js
@@ -1,0 +1,108 @@
+import { LitElement, html, css } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+import { sparkline } from '/vendor/@fnando/sparkline@0.3.10/sparkline.js';
+import { generateMockSparklineData } from './mocks/sparkline.mocks.js';
+
+class SparklineChart extends LitElement {
+  static properties = {
+    data: { type: Array },
+    label: { type: String },
+    disabled: { type: Boolean },
+    mock: { type: Boolean }
+  };
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      position: relative;
+      border-bottom:1px solid #444;
+    }
+    svg {
+      width: auto;
+      height: 30px;
+    }
+    .tooltip {
+      position: absolute;
+      background: rgba(0, 0, 0, .7);
+      color: #fff;
+      padding: 2px 5px;
+      font-size: 12px;
+      white-space: nowrap;
+      z-index: 9999;
+      display: none;
+    }
+    .label {
+      font-size: var(--sl-font-size-x-small);
+    }
+    .label[disabled] {
+      color: grey;
+    }
+    .sparkline--cursor {
+      stroke: #ffbd11;
+    }
+    .sparkline--spot {
+      fill: white;
+      stroke: white;
+    }
+  `;
+
+  constructor() {
+    super();
+    this.dataToUse = [];
+    this.options = {
+      onmousemove: (event, datapoint, index) => {
+        if (this.disabled || datapoint === undefined) return;
+        const tooltip = this.shadowRoot.querySelector('.tooltip');
+        
+        tooltip.style.display = 'block';
+        tooltip.textContent = `Value: ${datapoint.value}`;
+        tooltip.style.top = `${event.offsetY}px`;
+        tooltip.style.left = `${event.offsetX + 20}px`;
+      },
+      onmouseout: () => {
+        if (this.disabled) return;
+        const tooltip = this.shadowRoot.querySelector('.tooltip');
+        tooltip.style.display = 'none';
+      }
+    };
+  }
+
+  render() {
+    const fill = this.disabled ? "rgba(255, 255, 255, 0.1)" : "rgb(7, 255, 174, 0.2)";
+    return html`
+      ${this.label ? html`<span class="label" ?disabled=${this.disabled}>${this.label}</span>` : ''}
+      <svg
+        part="sparkline-svg"
+        width="100" height="30"
+        stroke-width="2"
+        stroke="${this.disabled ? 'grey' : 'rgb(7, 255, 174)'}"
+        fill="${fill}">
+      </svg>
+      <div class="tooltip"></div>
+    `;
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('data') || changedProperties.has('mock')) {
+      this.drawSparkline();
+    }
+  }
+
+  drawSparkline() {
+    if (this.mock) {
+      const mockDataCount = 10;
+      this.dataToUse = generateMockSparklineData(mockDataCount);
+    } else if (Array.isArray(this.data)) {
+      this.dataToUse = this.data.map(item => 
+        typeof item === 'number' ? item : (item.value || 0)
+      );
+    } else {
+      this.dataToUse = [];
+    }
+
+    const svg = this.shadowRoot.querySelector('svg[part="sparkline-svg"]');
+    sparkline(svg, this.dataToUse, this.options);
+  }
+}
+
+customElements.define('sparkline-chart-v2', SparklineChart);

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -11,6 +11,7 @@ import "/components/common/action-row/action-row.js";
 import "/components/common/dynamic-form/dynamic-form.js";
 import "/components/views/x-check/index.js";
 import "/components/common/page-container.js";
+import "/components/common/sparkline-chart/sparkline-chart-v2.js";
 import { bindToClass } from "/utils/class-bind.js";
 import * as renderMethods from "./renders/index.js";
 import { store } from "/state/store.js";
@@ -257,6 +258,56 @@ class PupPage extends LitElement {
       `
     }
 
+    const renderStats = () => {
+      const metrics = Object.entries(pkg.stats.metrics).filter(([key, value]) => 
+        Array.isArray(value) && value.every(item => typeof item === 'number')
+      );
+
+      if (metrics.length === 0) {
+        return html`
+          <div class="metrics-wrap">
+            <small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty. Pup reports no metrics</small>
+          </div>
+        `;
+      }
+
+      return html`
+        <div class="metrics-wrap">
+          ${metrics.map(([key, value]) => html`
+            <div class="metric-container">
+              <sparkline-chart-v2 .data="${value}" .label="${key}"></sparkline-chart-v2>
+            </div>
+          `)}
+        </div>
+      `;
+    };
+
+    const renderResources = () => {
+    const resourceKeys = ["statusCpuPercent", "statusMemTotal", "statusMemPercent", "statusDisk"];
+
+    const metrics = resourceKeys
+      .filter(key => Array.isArray(pkg.stats[key]) && pkg.stats[key].every(item => typeof item === 'number'))
+      .map(key => [key, pkg.stats[key]]);
+
+    if (metrics.length === 0) {
+      return html`
+        <div class="metrics-wrap">
+          <p class="no-metrics">No resource metrics available</p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="metrics-wrap">
+        ${metrics.map(([key, value]) => html`
+          <div class="metric-container">
+            <sparkline-chart-v2 .data="${value}" .label="${key}"></sparkline-chart-v2>
+          </div>
+        `)}
+      </div>
+    `;
+  };
+
     const renderMenu = () => html`
       <action-row prefix="power" name="state" label="Enabled" ?disabled=${disableActions}>
         Enable or disable this Pup
@@ -312,6 +363,13 @@ class PupPage extends LitElement {
 
         <section>
           <div class=${sectionTitleClasses}>
+            <h3>Stats</h3>
+          </div>
+          ${renderStats()}
+        </section>
+
+        <section>
+          <div class=${sectionTitleClasses}>
             <h3>Menu</h3>
           </div>
           <div class="list-wrap">${renderMenu()}</div>
@@ -331,6 +389,13 @@ class PupPage extends LitElement {
             <h3>Such More</h3>
           </div>
           <div class="list-wrap">${renderMore()}</div>
+        </section>
+
+        <section>
+          <div class=${sectionTitleClasses}>
+            <h3>Resources</h3>
+          </div>
+          ${renderResources()}
         </section>
 
         <section>
@@ -421,6 +486,15 @@ class PupPage extends LitElement {
       &.uninstalling { --indicator-color: var(--sl-color-danger-600); }
       &.purging { --indicator-color: var(--sl-color-danger-600); }
     }
+
+    .metrics-wrap {
+      display: flex;
+      flex-direction: row;
+      gap: 1em;
+      overflow-x: auto;
+    }
+
+    .metric-container {}
   `;
 }
 


### PR DESCRIPTION
MVP of stats in panel

When pup reports no metrics:
<img width="607" alt="image" src="https://github.com/user-attachments/assets/4e0111f6-05d1-47ce-8aa3-1b5c06d9cf40">

When pup reports metrics:
<img width="427" alt="image" src="https://github.com/user-attachments/assets/d2f795b2-8c9a-40c3-a0f6-91593241f499">

For all pups, their resource stats are displayed:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/a2e3a503-fee4-4d4d-aef9-9ce9e949912f">
