### PR TITLE
Feature - Upstream Version Labels

### DIFF
--- a/src/components/common/reveal-row/reveal-row.js
+++ b/src/components/common/reveal-row/reveal-row.js
@@ -17,6 +17,10 @@ class RevealRow extends LitElement {
       font-size: 1rem;
     }
 
+    .wrap.has-more .collapsed {
+      cursor: pointer;
+    }
+
     .body-wrap {
       transition: max-height 0.2s ease-in-out;
       overflow: hidden;
@@ -25,7 +29,6 @@ class RevealRow extends LitElement {
 
     .collapsed {
       max-height: 7em;
-      cursor: pointer;
     }
 
     .expanded {
@@ -42,7 +45,7 @@ class RevealRow extends LitElement {
       display: none;
     }
 
-    shadow.show {
+    .shadow.show {
       display: var(--shadow-display, block);
     }
 
@@ -94,7 +97,7 @@ class RevealRow extends LitElement {
   render() {
     const showToggle = this.contentLength > 130;
     return html`
-      <div>
+      <div class="wrap ${showToggle ? 'has-more' : ''}">
         <div part="body" @click=${showToggle ? this.performExpand : null} class="body-wrap ${this.expanded ? 'expanded' : 'collapsed'}">
           <slot></slot>
           <div class="shadow ${showToggle ? 'show' : ''}"></div>

--- a/src/components/common/tag-set/tag-set.js
+++ b/src/components/common/tag-set/tag-set.js
@@ -1,0 +1,75 @@
+import { LitElement, html, css, nothing } from '/vendor/@lit/all@3.1.2/lit-all.min.js';
+
+class TagSet extends LitElement {
+
+  static get properties() {
+    return {
+      tags: { type: Object },
+      max: { type: Number },
+      highlight: { type: Boolean }
+    }
+  }
+
+  render() {
+    if (!this.tags || typeof this.tags !== 'object' || Object.keys(this.tags).length === 0) {
+      return nothing;
+    }
+
+    const entries = Object.entries(this.tags);
+    const displayCount = this.max || 3;
+    const remainingCount = entries.length - displayCount;
+    const remainingString = entries.slice(displayCount)
+      .map(([key, value]) => `${key}:${value}`)
+      .join(',\n');
+
+    return html`
+      ${entries.slice(0, displayCount).map(([key, value], index) => {
+        const variant = (this.highlight && index === 0) ? 'success' : 'neutral';
+        return html`
+          <sl-tag size="small" variant="${variant}">
+            <span class="tag-key">${key}</span>:&nbsp;
+            <span class="tag-value">${value}</span>
+          </sl-tag>
+        `;
+      })}
+      ${remainingCount > 0 ? html`
+        <sl-tooltip content="${remainingString}">
+          <sl-tag size="small" variant="neutral">+${remainingCount} more</sl-tag>
+        </sl-tooltip>
+      ` : ''}
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
+      font-size: 0.7rem;
+      align-items: center;
+      gap: 0.25em;
+      min-width: 300px;
+      overflow: hidden;
+    }
+
+    .tag-key {
+      max-width: 90px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+      vertical-align: bottom;
+    }
+
+    .tag-value {
+      max-width: 120px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: inline-block;
+      vertical-align: bottom;
+    }
+  `
+}
+
+customElements.define('x-tag-set', TagSet);

--- a/src/components/views/card-pup-install/index.js
+++ b/src/components/views/card-pup-install/index.js
@@ -5,6 +5,8 @@
     nothing,
   } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
+  import "/components/common/tag-set/tag-set.js";
+
   class PupInstallCard extends LitElement {
     static get properties() {
       return {
@@ -18,7 +20,8 @@
         running: { type: Boolean },
         hasGui: { type: Boolean },
         href: { type: String },
-        gref: { type: String }
+        gref: { type: String },
+        upstreamVersions: { type: Object },
       };
     }
 
@@ -38,7 +41,7 @@
     }
 
     render() {
-      const { defaultIcon, pupName, version, logoBase64, status, gui, short, href } = this;
+      const { defaultIcon, pupName, version, logoBase64, status, gui, short, href, upstreamVersions } = this;
       return html`
         <a class="anchor" href=${href} target="_self">
           <div class="pup-card-wrap">
@@ -47,8 +50,9 @@
             </div>
             <div class="details-wrap">
               <div class="inner">
-                <span class="name">${pupName}</span>
+                <span class="name">${pupName}  <small style="color: #777">v${version}</small></span>
                 <span class="description">${short}</span>
+                <x-tag-set .tags=${upstreamVersions} highlight max=1></x-tag-set>
                 <span class="status">${status === "running" ? "Installed" : status}</span>
               </div>
             </div>
@@ -60,7 +64,7 @@
     static styles = css`
       :host {
         --icon-size: 72px;
-        --row-height: 84px;
+        --row-height: 114px;
       }
 
       a, button {
@@ -84,6 +88,7 @@
         width: 100%;
         padding: 1em;
         box-sizing: border-box;
+        overflow: hidden;
       }
 
       .pup-card-wrap:hover {
@@ -130,9 +135,29 @@
         font-family: 'Comic Neue';
         font-size: 1.2rem;
         font-weight: bold;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-height: 2.4em;
+        line-height: 1.2em;
       }
 
       span.description {
+        margin-bottom: 4px;
+        font-weight: 100;
+        font-size: 0.9rem;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-height: 2em;
+        line-height: 1em;
+      }
+
+      span.version {
         font-weight: 100;
         font-size: 0.9rem;
       }

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -6,6 +6,8 @@
     classMap
   } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
+  import "/components/common/tag-set/tag-set.js";
+
   class PupCard extends LitElement {
     static get properties() {
       return {
@@ -18,7 +20,8 @@
         running: { type: Boolean },
         hasGui: { type: Boolean },
         href: { type: String },
-        gref: { type: String }
+        gref: { type: String },
+        upstreamVersions: { type: Object },
       };
     }
 
@@ -34,24 +37,6 @@
       this._status = newStatus;
       this.running = newStatus === 'running';
       this.requestUpdate();
-    }
-
-    renderUpstreamVersions(upstreamVersions) {
-      const entries = Object.entries(upstreamVersions);
-      const displayCount = 3;
-      const remainingCount = entries.length - displayCount;
-
-      return html`
-        ${entries.slice(0, displayCount).map(([key, value], index) => {
-          const variant = index === 0 ? 'success' : 'neutral';
-          return html`
-            <sl-tag size="small" variant="${variant}">${key}: ${value}</sl-tag>
-          `;
-        })}
-        ${remainingCount > 0 ? html`
-          <sl-tag size="small" variant="neutral">+${remainingCount} more</sl-tag>
-        ` : ''}
-      `;
     }
 
     render() {
@@ -71,9 +56,7 @@
             <div class="details-wrap">
               <div class="inner">
                 <span class="name">${pupName} <small style="color: #777">v${version}</small></span>
-                <div class="labels">
-                  ${this.renderUpstreamVersions(upstreamVersions)}
-                </div>
+                <x-tag-set .tags=${upstreamVersions} highlight max=1></x-tag-set>
                 <span class=${statusClassMap}>${status}</span>
               </div>
             </div>
@@ -180,19 +163,6 @@
         font-size: 1.2rem;
         font-weight: bold;
       }
-
-      div.labels {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        font-size: 0.7rem;
-        align-items: center;
-        gap: 0.25em;
-        min-width: 300px;
-        overflow: hidden;
-      }
-
-      div.labels .service {}
 
       span.version {
         font-weight: 100;

--- a/src/components/views/card-pup-manage/index.js
+++ b/src/components/views/card-pup-manage/index.js
@@ -36,8 +36,27 @@
       this.requestUpdate();
     }
 
+    renderUpstreamVersions(upstreamVersions) {
+      const entries = Object.entries(upstreamVersions);
+      const displayCount = 3;
+      const remainingCount = entries.length - displayCount;
+
+      return html`
+        ${entries.slice(0, displayCount).map(([key, value], index) => {
+          const variant = index === 0 ? 'success' : 'neutral';
+          return html`
+            <sl-tag size="small" variant="${variant}">${key}: ${value}</sl-tag>
+          `;
+        })}
+        ${remainingCount > 0 ? html`
+          <sl-tag size="small" variant="neutral">+${remainingCount} more</sl-tag>
+        ` : ''}
+      `;
+    }
+
     render() {
-      const { defaultIcon, logoBase64, pupName, version, status, hasGui, href, gref } = this;
+      const { defaultIcon, logoBase64, pupName, version, status, hasGui, href, gref, upstreamVersions } = this;
+
       const statusClassMap = classMap({
         status: true,
         running: status === "running"
@@ -51,8 +70,10 @@
 
             <div class="details-wrap">
               <div class="inner">
-                <span class="name">${pupName}</span>
-                <span class="version">${version}</span>
+                <span class="name">${pupName} <small style="color: #777">v${version}</small></span>
+                <div class="labels">
+                  ${this.renderUpstreamVersions(upstreamVersions)}
+                </div>
                 <span class=${statusClassMap}>${status}</span>
               </div>
             </div>
@@ -76,7 +97,7 @@
     static styles = css`
       :host {
         --icon-size: 72px;
-        --row-height: 84px;
+        --row-height: 114px;
       }
 
       a, button {
@@ -96,6 +117,7 @@
         width: 100%;
         padding: 1em;
         box-sizing: border-box;
+        overflow: hidden;
       }
 
       .pup-card-wrap:hover {
@@ -135,7 +157,7 @@
         display: flex;
         flex-direction: column;
         align-items: start;
-        line-height: 1.3;
+        line-height: 1.5;
       }
 
       .suffix-wrap {
@@ -159,13 +181,26 @@
         font-weight: bold;
       }
 
+      div.labels {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        font-size: 0.7rem;
+        align-items: center;
+        gap: 0.25em;
+        min-width: 300px;
+        overflow: hidden;
+      }
+
+      div.labels .service {}
+
       span.version {
         font-weight: 100;
         font-size: 0.9rem;
       }
 
       span.status {
-        line-height: 1.5;
+        line-height: 1.7;
         text-transform: capitalize;
         font-size: 0.9rem;
         color: grey;

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -373,22 +373,9 @@ class PupPage extends LitElement {
             <h3>About</h3>
           </div>
           <reveal-row style="margin-top:-1em;">
-            ${short && long
-              ? html`
-                <p>${short}</p>
-                <p>${long}</p>
-                `
-              : nothing
-            }
-
-            ${short || long
-              ? html`<p>${short || long}</p>`
-              : nothing
-            }
-
-            ${!short && !long
-              ? html`<small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty, no description.</small>`
-              : nothing
+            ${long
+              ? html`<p>${long}</p>`
+              : html`<small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty, no description.</small>`
             }
           </reveal-row>
         </section>

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -72,6 +72,7 @@ export function renderSectionInstalledBody(ready, SKELS, hasItems) {
               version=${pkg.state.version}
               logoBase64=${pkg?.assets?.logos?.mainLogoBase64}
               status=${pkg.computed.statusLabel}
+              .upstreamVersions=${pkg.state.manifest?.meta?.upstreamVersions || {}}
               href=${pkg.computed.libraryURL}
               gref=${pkg.computed.pupURL}
               ?hasGui=${false}

--- a/src/pages/page-pup-library/renders/section_installed.js
+++ b/src/pages/page-pup-library/renders/section_installed.js
@@ -3,8 +3,7 @@ import { html, css, nothing, repeat } from '/vendor/@lit/all@3.1.2/lit-all.min.j
 var pupCardGrid = css`
   .pup-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1em;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
   }
 `
 

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -149,22 +149,9 @@ class PupInstallPage extends LitElement {
           <div class="section-title">
             <h3>About</h3>
             <reveal-row style="margin-top:-1em;">
-              ${short && long
-                ? html`
-                  <p>${short}</p>
-                  <p>${long}</p>
-                  `
-                : nothing
-              }
-
-              ${short || long
-                ? html`<p>${short || long}</p>`
-                : nothing
-              }
-
-              ${!short && !long
-                ? html`<p>Such empty, no description provided.</p>`
-                : nothing
+              ${long
+                ? html`<p>${long}</p>`
+                : html`<small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty, no description.</small>`
               }
             </reveal-row>
           </div>

--- a/src/pages/page-pup-store/renders/section_body.js
+++ b/src/pages/page-pup-store/renders/section_body.js
@@ -3,8 +3,7 @@ import { html, css, nothing, repeat } from '/vendor/@lit/all@3.1.2/lit-all.min.j
 var pupCardGrid = css`
   .pup-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 1em;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
   }
 `
 
@@ -51,7 +50,8 @@ export function renderSectionBody(ready, SKELS, hasItems) {
 
     ${ready && hasItems('packages') ? html`
       <div class="pup-card-grid">
-        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def.source.id}-${pkg.def.key}`, (pkg) => html`
+        ${repeat(this.packageList.getCurrentPageData(), (pkg) => `${pkg.def.source.id}-${pkg.def.key}`, (pkg) => {
+          return html`
           <pup-install-card
             defaultIcon="box"
             sourceId=${pkg.def.source.id}
@@ -59,11 +59,12 @@ export function renderSectionBody(ready, SKELS, hasItems) {
             pupName=${pkg.def.key}
             version=${pkg.def.latestVersion}
             logoBase64=${pkg.def.logoBase64}
+            .upstreamVersions=${pkg.def.versions[pkg.def.latestVersion]?.meta?.upstreamVersions || {}}
             short="${pkg.def.versions[pkg.def.latestVersion]?.meta?.shortDescription}"
             ?installed=${pkg.computed.isInstalled}
             href=${pkg.computed.storeURL}
           ></pup-install-card>
-        `)}
+        `})}
       </div>
       <style>${pupCardGrid}</style>
 


### PR DESCRIPTION
Todo

- [X] Show upstream version labels on store cards
- [X] Show upstream version labels on library cards
- [X] Clip text at reasonable lengths

Additionally
- [X] Tidy up descriptions on store and library pup listing pages

Screenshots:

Store
![Screenshot 2024-09-25 at 2 30 23 PM](https://github.com/user-attachments/assets/60049dd0-68e8-4767-9200-684c7a4d3487)

Library: 
![Screenshot 2024-09-25 at 2 30 27 PM](https://github.com/user-attachments/assets/d0540534-9693-485e-8466-b427bf8c05a5)



