### PR TITLE
Various fixes and tidies

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ import "/components/views/prompt-system/index.js";
 
 // Components
 import "/utils/debug-panel.js";
+import { notYet } from "/components/common/not-yet-implemented.js";
 
 // Render chunks
 import * as renderMethods from "/components/layouts/standard/renders/index.js";

--- a/src/components/layouts/standard/renders/nav.js
+++ b/src/components/layouts/standard/renders/nav.js
@@ -1,4 +1,5 @@
 import { html, classMap } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { notYet } from "/components/common/not-yet-implemented.js";
 
 export function renderNav(CURPATH) {
   const gutterNavClasses = classMap({
@@ -34,12 +35,12 @@ export function renderNav(CURPATH) {
               Explore
             </a>
 
-            <a href="/stats" class="menu-item ${CURPATH.startsWith("/stats") ? "active" : ""}">
+            <a href="/stats" @click="${(e) => { e.stopPropagation(); e.preventDefault(); notYet(); }}" class="menu-item ${CURPATH.startsWith("/stats") ? "active" : ""}">
               <sl-icon name="heart-pulse-fill"></sl-icon>
               Monitor
             </a>
 
-            <a href="/settings" class="menu-item ${CURPATH.startsWith("/settings") ? "active" : ""}">
+            <a href="/settings" @click="${(e) => { e.stopPropagation(); e.preventDefault(); notYet(); }}" class="menu-item ${CURPATH.startsWith("/settings") ? "active" : ""}">
               <sl-icon name="sliders"></sl-icon>
               Settings
             </a>

--- a/src/components/views/action-dependency-manage/dependency.js
+++ b/src/components/views/action-dependency-manage/dependency.js
@@ -333,7 +333,7 @@ class DependencyList extends LitElement {
           ? html`
               <div class="empty">
                 Wow, such independence.<br />
-                This pup has no dependencies. That's cool too.
+                This pup has no dependencies.
               </div>
             `
           : nothing}

--- a/src/components/views/action-interface-list/interface.js
+++ b/src/components/views/action-interface-list/interface.js
@@ -21,6 +21,9 @@ export class InterfaceList extends LitElement {
   }
 
   render() {
+    if (!this.interfaces || !this.interfaces.length) {
+      return;
+    }
 
     const renderSeverityOptions = (severityNumber) => {
       if (!severityNumber || severityNumber < 1 || severityNumber > 3) {
@@ -40,7 +43,7 @@ export class InterfaceList extends LitElement {
     };
 
     const renderPermissionGroup = (group) => {
-      const routeCount = group.routes.length;
+      const routeCount = group?.routes?.length || 0;
       const routeLabel = routeCount === 1 ? "Route" : "Routes";
 
       return html`
@@ -53,11 +56,13 @@ export class InterfaceList extends LitElement {
             <span class="label">Permission description</span>
             <span class="value">${group.description}</span>
           </div>
-          <sl-divider></sl-divider>
-          <div class="routes">
-            <div class="label">${routeCount} ${routeLabel}:</div>
-            <div class="value">${group.routes.map((r) => html`${r}`)}</div>
-          </div>
+          ${group.routes && group.routes.length ? html`
+            <sl-divider></sl-divider>
+            <div class="routes">
+              <div class="label">${routeCount} ${routeLabel}:</div>
+              <div class="value">${group.routes.map((r) => html`${r}`)}</div>
+            </div>`: nothing
+          }
           <sl-divider></sl-divider>
           <div class="severity">
             <span class="label">Severity:</span>

--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -337,6 +337,10 @@ class PupPage extends LitElement {
       <action-row prefix="boxes" name="deps" label="Dependencies" .trigger=${this.handleMenuClick}>
         Functionality this pup depends on from other pups.
       </action-row>
+
+      <action-row prefix="box-arrow-up" name="ints" label="Interfaces" .trigger=${this.handleMenuClick}>
+        Functionality this pup provides for other pups.
+      </action-row>
     `
 
     const renderCareful = () => html`

--- a/src/pages/page-pup-library-listing/renders/dialog.js
+++ b/src/pages/page-pup-library-listing/renders/dialog.js
@@ -11,7 +11,9 @@ export function renderDialog() {
   const { statusId } = pkg.computed
   const readmeEl = html`<div style="padding: 1em; text-align: center;"> Such empty. This pup does not provide a README.</div>`;
   const deps = pkg?.state?.manifest?.dependencies || [];
+  const ints = pkg?.state?.manifest?.interfaces || [];
   const depsEl = html`<x-action-manage-deps .dependencies=${deps} .providers=${pkg.state.providers} editMode pupId=${pkg.state.id}></x-action-manage-deps>`;
+  const intsEl = html`<x-action-interface-list .interfaces=${ints}></x-action-interface-list>`;
 
   const preventUninstallEl = html`
     <p>Cannot uninstall a running Pup.<br/>Please disable ${pkg.state.manifest.meta.name } and try again.</p>
@@ -46,6 +48,7 @@ export function renderDialog() {
       [
         ["readme", () => readmeEl],
         ["deps", () => depsEl],
+        ["ints", () => intsEl],
         ["configure", () => configEl],
         ["uninstall", () => isStopped ? uninstallEl : preventUninstallEl],
       ],

--- a/src/pages/page-pup-store/index.js
+++ b/src/pages/page-pup-store/index.js
@@ -196,12 +196,14 @@ class StoreView extends LitElement {
     const SKELS = Array.from({ length: 1 })
 
     return html`
-      <page-banner title="Dogecoin" subtitle="Registry">
-        Extend your Dogebox with Pups<br/>
-        <sl-button size="large" variant="text" ?disabled=${this.fetchLoading} @click=${this.handleManageSourcesClick}>
-          <sl-icon name="database-fill-add" slot="prefix"></sl-icon>
-          Manage Sources
-        </sl-button>
+      <page-banner title="Pup Store" subtitle="Dogebox">
+        <div class="slogan-wrap">
+          Extend your Dogebox with Pups
+          <sl-button size="large" variant="text" ?disabled=${this.fetchLoading} @click=${this.handleManageSourcesClick}>
+            <sl-icon name="database-fill-add" slot="prefix"></sl-icon>
+            Manage Sources
+          </sl-button>
+        </div>
       </page-banner>
 
       <div class="row search-wrap">
@@ -282,6 +284,20 @@ class StoreView extends LitElement {
       padding: var(--sl-spacing-x-large) var(--sl-spacing-medium);
       font-family: 'Comic Neue', sans-serif;
       text-align: center;
+    }
+
+    .slogan-wrap {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      @media (min-width: 800px) {
+        display: flex;
+        flex-direction: row;
+        gap: 1.5em;
+        justify-content: center;
+        align-items: center;
+      }
     }
   `
 }

--- a/src/router/config.js
+++ b/src/router/config.js
@@ -1,11 +1,15 @@
 import { isAuthed, loadPup, asPage, performLogout } from "./middleware.js"
 
 export const routes = [
+  // {
+  //   path: "/",
+  //   component: "x-page-home",
+  //   pageTitle: "Home",
+  //   before: [isAuthed, asPage]
+  // },
   {
     path: "/",
-    component: "x-page-home",
-    pageTitle: "Home",
-    before: [isAuthed, asPage]
+    before:[(ctx, cmd) => cmd.redirect("/explore")]
   },
   {
     path: "/logout",


### PR DESCRIPTION
- [X] "/" now routes to "/explore", making Explore the homepage for now
- [X] Fixed issue with interface modal assuming every permission group had routes.
- [X] adds NotYetImplemented modal to monitor and settings menu items.
- [X] adds Interfaces to pup library listing page (previously only shown on store page)