### PR TITLE
Recovery UI updates

### DIFF
--- a/src/api/action/action.js
+++ b/src/api/action/action.js
@@ -11,7 +11,7 @@ import {
 
 import { setProvider } from '../providers/providers.js';
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function installPup(pupId, body) {
   return client.put(`/pup`, body, { mock: installMock });

--- a/src/api/bootstrap/bootstrap.js
+++ b/src/api/bootstrap/bootstrap.js
@@ -4,7 +4,7 @@ import { pkgController } from '/controllers/package/index.js';
 import { mock } from './bootstrap.mocks.js'
 import { mockV2 } from './bootstrap.mocks.v2.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getBootstrap() {
   return client.get('/setup/bootstrap', { mock });

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -12,7 +12,7 @@ export default class ApiClient extends ReactiveClass {
     this.networkContext = this.context.store.networkContext;
     this.options = options;
 
-    if (this.networkContext && this.networkContext.overrideBaseUrl) {
+    if (this.networkContext && this.networkContext.overrideBaseUrl && !this.options.externalAPI) {
       this.baseURL = this.networkContext.apiBaseUrl || 'http://nope.localhost:6969';
     }
   }

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -4,12 +4,13 @@ import { ReactiveClass } from "/utils/class-reactive.js";
 import { StoreSubscriber } from "/state/subscribe.js";
 
 export default class ApiClient extends ReactiveClass {
-  constructor(baseURL, networkContext = {}) {
+  constructor(baseURL, options = {}) {
     super();
     this.baseURL = baseURL
 
     this.context = new StoreSubscriber(this, store);
     this.networkContext = this.context.store.networkContext;
+    this.options = options;
 
     if (this.networkContext && this.networkContext.overrideBaseUrl) {
       this.baseURL = this.networkContext.apiBaseUrl || 'http://nope.localhost:6969';
@@ -65,7 +66,7 @@ export default class ApiClient extends ReactiveClass {
     const url = new URL(path, this.baseURL).href;
     const headers = { 'Content-Type': 'application/json', ...config.headers };
 
-    if (this.networkContext.token) {
+    if (this.networkContext.token && !this.options.externalAPI) {
       headers.Authorization = `Bearer ${this.networkContext.token}`
     }
 

--- a/src/api/config/config.js
+++ b/src/api/config/config.js
@@ -7,7 +7,7 @@ import {
   getAllResponse,
 } from './config.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function postConfig(pupId, body) {
   return client.post(`/config/${pupId}`, body, { mock: postResponse });

--- a/src/api/keys/create-key.js
+++ b/src/api/keys/create-key.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './create-key.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function createKey(password) {
   const res = await client.post(`/keys/create-master`, { password }, { mock: postResponse });

--- a/src/api/keys/get-keylist.js
+++ b/src/api/keys/get-keylist.js
@@ -3,7 +3,7 @@ import { store } from "/state/store.js";
 
 import { getResponse } from "./get-keylist.mocks.js";
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext);
+const client = new ApiClient(store.networkContext.apiBaseUrl);
 
 export async function getKeylist() {
   const res = await client.get(`/keys`, { mock: getResponse });

--- a/src/api/login/login.js
+++ b/src/api/login/login.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './login.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function postLogin(body) {
   const res = await client.post(`/authenticate`, body, { mock: postResponse });

--- a/src/api/manifest/manifest.js
+++ b/src/api/manifest/manifest.js
@@ -5,7 +5,7 @@ import {
   generateManifests
 } from './manifest.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getManifest() {
   return client.get('/manifest/', { mock: generateManifests });

--- a/src/api/network/get-networks.js
+++ b/src/api/network/get-networks.js
@@ -5,7 +5,7 @@ import {
   getResponse,
 } from './get-networks.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getNetworks(body) {
   const res = await client.get(`/system/network/list`, { mock: getResponse });

--- a/src/api/network/set-network.js
+++ b/src/api/network/set-network.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './set-network.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function putNetwork(body) {
   const res = await client.put(`/system/network/set-pending`, body, { mock: postResponse });

--- a/src/api/password/change-pass.js
+++ b/src/api/password/change-pass.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './change-pass.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function postChangePass(body) {
   const res = await client.post(`/auth/change-pass`, body, { mock: postResponse });

--- a/src/api/providers/providers.js
+++ b/src/api/providers/providers.js
@@ -6,7 +6,7 @@ import {
   setProviderResponse,
 } from './providers.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getProviders(pupId) {
   const res = await client.get(`/providers/${pupId}`, { mock: getProvidersResponse });

--- a/src/api/reflector/get-ip.js
+++ b/src/api/reflector/get-ip.js
@@ -1,11 +1,12 @@
 import ApiClient from '/api/client.js';
+import { store } from "/state/store.js";
 
 import { 
   getResponse,
 } from './get-ip.mocks.js'
 
-export async function getIP(reflectorHost, reflectorToken) {
-  const client = new ApiClient(reflectorHost, {
+export async function getIP(reflectorToken) {
+  const client = new ApiClient(store.networkContext.reflectorHost, {
     // Set externalAPI so we don't leak our authentication token to the reflector.
     externalAPI: true
   })

--- a/src/api/reflector/get-ip.js
+++ b/src/api/reflector/get-ip.js
@@ -1,13 +1,15 @@
 import ApiClient from '/api/client.js';
-import { store } from '/state/store.js'
 
 import { 
   getResponse,
 } from './get-ip.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+export async function getIP(reflectorHost, reflectorToken) {
+  const client = new ApiClient(reflectorHost, {
+    // Set externalAPI so we don't leak our authentication token to the reflector.
+    externalAPI: true
+  })
 
-export async function getIP() {
-  const res = await client.get(`/reflector/ip`, { mock: getResponse });
+  const res = await client.get(`/${reflectorToken}`, { mock: getResponse });
   return res
 }

--- a/src/api/reflector/get-ip.mocks.js
+++ b/src/api/reflector/get-ip.mocks.js
@@ -1,10 +1,8 @@
 export const getResponse = {
-  name: "/reflector/:ip",
-  group: "setup",
+  name: "/:token",
+  group: "Reflector",
   method: "get",
   res: {
-    success: true,
     ip: "192.168.0.57",
-    lastSeen: Date.now(),
   }
 }

--- a/src/api/sources/manage.js
+++ b/src/api/sources/manage.js
@@ -15,7 +15,7 @@ export const sourceAddMock = {
   res: { success: true }
 }
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function removeSource(sourceId) {
   return client.delete(`/source/${sourceId}`, null, { mock: sourceRemovalMock });

--- a/src/api/sources/sources.js
+++ b/src/api/sources/sources.js
@@ -6,7 +6,7 @@ import {
   storeListingMock
 } from './sources.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getStoreListing(shouldFlush = false) {
   const url = shouldFlush ? '/sources/store?refresh=true' : '/sources/store';

--- a/src/api/system/get-bootstrap.js
+++ b/src/api/system/get-bootstrap.js
@@ -5,7 +5,7 @@ import {
   getResponse,
 } from './get-bootstrap.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function getSetupBootstrap(body) {
   const res = await client.get(`/system/bootstrap`, { mock: getResponse });

--- a/src/api/system/post-bootstrap.js
+++ b/src/api/system/post-bootstrap.js
@@ -5,7 +5,7 @@ import {
   postResponse,
 } from './post-bootstrap.mocks.js'
 
-const client = new ApiClient(store.networkContext.apiBaseUrl, store.networkContext)
+const client = new ApiClient(store.networkContext.apiBaseUrl)
 
 export async function postSetupBootstrap(body) {
   const res = await client.post(`/system/bootstrap`, body, { mock: postResponse });

--- a/src/api/system/post-host-reboot.js
+++ b/src/api/system/post-host-reboot.js
@@ -1,0 +1,13 @@
+import ApiClient from '/api/client.js';
+import { store } from '/state/store.js'
+
+import { 
+  postResponse,
+} from './post-host-reboot.mocks.js'
+
+const client = new ApiClient(store.networkContext.apiBaseUrl)
+
+export async function postHostReboot() {
+  const res = await client.post(`/system/host/reboot`, {}, { mock: postResponse });
+  return res
+}

--- a/src/api/system/post-host-reboot.mocks.js
+++ b/src/api/system/post-host-reboot.mocks.js
@@ -1,0 +1,8 @@
+export const postResponse = {
+  name: "/system/host/reboot",
+  method: "post",
+  group: "system",
+  res: {
+    success: true
+  }
+};

--- a/src/api/system/post-host-shutdown.js
+++ b/src/api/system/post-host-shutdown.js
@@ -1,0 +1,13 @@
+import ApiClient from '/api/client.js';
+import { store } from '/state/store.js'
+
+import { 
+  postResponse,
+} from './post-host-shutdown.mocks.js'
+
+const client = new ApiClient(store.networkContext.apiBaseUrl)
+
+export async function postHostShutdown() {
+  const res = await client.post(`/system/host/shutdown`, {}, { mock: postResponse });
+  return res
+}

--- a/src/api/system/post-host-shutdown.mocks.js
+++ b/src/api/system/post-host-shutdown.mocks.js
@@ -1,0 +1,8 @@
+export const postResponse = {
+  name: "/system/host/shutdown",
+  method: "post",
+  group: "system",
+  res: {
+    success: true
+  }
+};

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -68,6 +68,10 @@ class AppModeApp extends LitElement {
     this.setupState = null;
     bindToClass(renderChunks, this);
     this.context = new StoreSubscriber(this, store);
+
+    this.reflectorToken = Math.random().toString(36).substring(2, 14);
+    // this.reflectorHost = 'https://reflector.dogebox.org'
+    this.reflectorHost = "http://127.0.0.1:9999"
   }
 
   set setupState(newValue) {
@@ -225,11 +229,16 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-select-network
                             .onSuccess=${async () => { await asyncTimeout(750); this._nextStep() }}
+                            .reflectorHost=${this.reflectorHost}
+                            .reflectorToken=${this.reflectorToken}
                           ></x-action-select-network>`,
                       ],
                       [
                         STEP_DONE,
-                        () => html`<x-page-recovery></x-page-recovery>`,
+                        () => html`<x-page-recovery
+                          .reflectorHost=${this.reflectorHost}
+                          .reflectorToken=${this.reflectorToken}
+                        ></x-page-recovery>`,
                       ],
                     ],
                     () => html`<h1>Error</h1>`,

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -58,6 +58,7 @@ class AppModeApp extends LitElement {
     isLoggedIn: { type: Boolean },
     activeStepNumber: { type: Number },
     setupState: { type: Object },
+    isFirstTimeSetup: { type: Boolean },
   };
 
   constructor() {
@@ -66,6 +67,8 @@ class AppModeApp extends LitElement {
     this.isLoggedIn = false;
     this.activeStepNumber = 0;
     this.setupState = null;
+    this.isFirstTimeSetup = false;
+
     bindToClass(renderChunks, this);
     this.context = new StoreSubscriber(this, store);
 
@@ -107,6 +110,10 @@ class AppModeApp extends LitElement {
 
   _determineStartingStep(setupState) {
     const { hasCompletedInitialConfiguration, hasGeneratedKey, hasConfiguredNetwork } = setupState;
+
+    if (!hasCompletedInitialConfiguration) {
+      this.isFirstTimeSetup = true;
+    }
 
     // If we're already fully set up, or if we've generated a key, show our login step.
     if ((hasCompletedInitialConfiguration || hasGeneratedKey) && !this.isLoggedIn) {
@@ -185,10 +192,10 @@ class AppModeApp extends LitElement {
         ? html`
             <div id="App" class="chrome">
               <nav class="${navClasses}">
-                ${guard([this.activeStepNumber, this.context.store.networkContext.token], () => this.renderNav())}
+                ${guard([this.isFirstTimeSetup, this.activeStepNumber, this.context.store.networkContext.token], () => this.renderNav(this.isFirstTimeSetup))}
               </nav>
 
-              <main id="Main">
+              <main id="Main" style="padding-top: ${this.isFirstTimeSetup ? '0px;' : '100px'}">
                 <div class="${stepWrapperClasses}">
                   ${choose(
                     this.activeStepNumber,
@@ -238,6 +245,7 @@ class AppModeApp extends LitElement {
                         () => html`<x-page-recovery
                           .reflectorHost=${this.reflectorHost}
                           .reflectorToken=${this.reflectorToken}
+                          .isFirstTimeSetup=${this.isFirstTimeSetup}
                         ></x-page-recovery>`,
                       ],
                     ],

--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -77,8 +77,6 @@ class AppModeApp extends LitElement {
     this.context = new StoreSubscriber(this, store);
 
     this.reflectorToken = Math.random().toString(36).substring(2, 14);
-    // this.reflectorHost = 'https://reflector.dogebox.org'
-    this.reflectorHost = "http://127.0.0.1:9999"
   }
 
   set setupState(newValue) {
@@ -260,14 +258,12 @@ class AppModeApp extends LitElement {
                         () =>
                           html`<x-action-select-network
                             .onSuccess=${async () => { await asyncTimeout(750); this._nextStep() }}
-                            .reflectorHost=${this.reflectorHost}
                             .reflectorToken=${this.reflectorToken}
                           ></x-action-select-network>`,
                       ],
                       [
                         STEP_DONE,
                         () => html`<x-page-recovery
-                          .reflectorHost=${this.reflectorHost}
                           .reflectorToken=${this.reflectorToken}
                           .isFirstTimeSetup=${this.isFirstTimeSetup}
                         ></x-page-recovery>`,

--- a/src/components/layouts/recovery/renders/nav.js
+++ b/src/components/layouts/recovery/renders/nav.js
@@ -23,6 +23,10 @@ export const navStyles = css`
     border-bottom: 1px solid var(--sl-input-border-color);
   }
 
+  nav.bottomPadding {
+    margin-bottom: 50px;
+  }
+
   nav .center-steps {
     display: flex;
     flex-direction: row;
@@ -99,7 +103,16 @@ export const navStyles = css`
   }
 `;
 
-export function renderNav() {
+export function renderNav(isFirstTimeSetup) {
+  if (!isFirstTimeSetup) {
+    return html`
+      <div class="recovery-mode-container" style="display: flex; gap: 0px 20px; justify-content: center; align-items: center;">
+        <img style="max-height: 150px;" src="/static/img/dogebox-logo-small.png" />
+        <span style="font-weight: bold; font-size: 2em; margin-top: 20px;">Dogebox Recovery Mode</span>
+      </div>
+    `
+  }
+
   const centerStepClasses = classMap({
     "center-steps": true,
     hidden: this.activeStepNumber === 0,

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -38,6 +38,8 @@ class SelectNetwork extends LitElement {
   static get properties() {
     return {
       showSuccessAlert: { type: Boolean },
+      reflectorToken: { type: String },
+      reflectorHost: { type: String },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
       _setNetworkFields: { type: Object },
@@ -276,8 +278,9 @@ class SelectNetwork extends LitElement {
     // TODO: move this into post-network flow.
     const finalSystemBootstrap = await postSetupBootstrap({
       hostname: state['device-name'],
-      reflectorToken: null,
-      initialSSHKey: state['ssh-key']
+      initialSSHKey: state['ssh-key'],
+      reflectorToken: this.reflectorToken,
+      reflectorHost: this.reflectorHost
     }).catch(() => { console.log('bootstrap called but no response returned')});
 
     // if (!finalSystemBootstrap) {

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -346,7 +346,7 @@ class SelectNetwork extends LitElement {
             <div style="margin-top: 2em;">
               <sl-alert variant="warning" open>
                 <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-                Hitting connect may take up to 10 minutes while we configure your Dogebox!
+                After you hit connect it may take up to 10 minutes while your Dogebox is configured!
               </sl-alert>
             </div>
         </div>

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -278,7 +278,8 @@ class SelectNetwork extends LitElement {
     const finalSystemBootstrap = await postSetupBootstrap({
       hostname: state['device-name'],
       initialSSHKey: state['ssh-key'],
-      reflectorToken: this.reflectorToken,
+      // Temporarily don't submit reflectorToken until the service is up and running.
+      // reflectorToken: this.reflectorToken,
       reflectorHost: store.networkContext.reflectorHost
     }).catch(() => { console.log('bootstrap called but no response returned')});
 

--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -39,7 +39,6 @@ class SelectNetwork extends LitElement {
     return {
       showSuccessAlert: { type: Boolean },
       reflectorToken: { type: String },
-      reflectorHost: { type: String },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
       _setNetworkFields: { type: Object },
@@ -280,7 +279,7 @@ class SelectNetwork extends LitElement {
       hostname: state['device-name'],
       initialSSHKey: state['ssh-key'],
       reflectorToken: this.reflectorToken,
-      reflectorHost: this.reflectorHost
+      reflectorHost: store.networkContext.reflectorHost
     }).catch(() => { console.log('bootstrap called but no response returned')});
 
     // if (!finalSystemBootstrap) {

--- a/src/components/views/confirmation-prompt/index.js
+++ b/src/components/views/confirmation-prompt/index.js
@@ -1,0 +1,47 @@
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+
+export class ConfirmationPrompt extends LitElement {
+  static get properties() {
+    return {
+      title: { type: String },
+      description: { type: String },
+      leftButtonText: { type: String },
+      leftButtonVariant: { type: String },
+      leftButtonClick: { type: Function },
+      rightButtonText: { type: String },
+      rightButtonVariant: { type: String },
+      rightButtonClick: { type: Function },
+    }
+  }
+
+  constructor() {
+    super();
+
+    this.title = this.title ?? 'Are you sure?'
+    this.leftButtonVariant = this.leftButtonVariant ?? 'text'
+    this.rightButtonVariant = this.rightButtonVariant ?? 'danger'
+
+    this._rightButtonClick = () => {
+      if (this.rightButtonClick) this.rightButtonClick()
+    }
+
+    this._leftButtonClick = () => {
+      if (this.leftButtonClick) this.leftButtonClick()
+    }
+  }
+
+  render() {
+    return html`
+      <div style="text-align: center;">
+        <h3>${this.title}</h3>
+        <p>${this.description}</p>
+      </div>
+      <div slot="footer" style="display: flex; justify-content: space-between;">
+        <sl-button variant="${this.leftButtonVariant}" @click=${this._leftButtonClick}>${this.leftButtonText}</sl-button>
+        <sl-button variant="${this.rightButtonVariant}" @click=${this._rightButtonClick}>${this.rightButtonText}</sl-button>
+      </div>
+    `;
+  }
+}
+
+customElements.define("x-confirmation-prompt", ConfirmationPrompt);

--- a/src/components/views/x-launcher-button/index.js
+++ b/src/components/views/x-launcher-button/index.js
@@ -8,7 +8,6 @@ class DogeboxLauncherButton extends LitElement {
 
   static get properties() {
     return {
-      reflectorHost: { type: String },
       reflectorToken: { type: String },
       _ready: { type: Boolean },
       _ip: { type: String }
@@ -42,7 +41,7 @@ class DogeboxLauncherButton extends LitElement {
   }
 
   async check() {
-    const res = await getIP(this.reflectorHost, this.reflectorToken);
+    const res = await getIP(this.reflectorToken);
     if (!res || res.error) {
       this.handleError(res)
       return;

--- a/src/components/views/x-launcher-button/index.js
+++ b/src/components/views/x-launcher-button/index.js
@@ -8,6 +8,8 @@ class DogeboxLauncherButton extends LitElement {
 
   static get properties() {
     return {
+      reflectorHost: { type: String },
+      reflectorToken: { type: String },
       _ready: { type: Boolean },
       _ip: { type: String }
     }
@@ -23,11 +25,10 @@ class DogeboxLauncherButton extends LitElement {
     this._intervalId = setInterval(() => {
       if (this._ready) {
         clearInterval(this._intervalId);
-        this._intervalId = setInterval(() => this.check(), 7000);
       } else {
         this.check();
       }
-    }, 10000);
+    }, 3000);
   }
 
   disconnectedCallback() {
@@ -41,9 +42,14 @@ class DogeboxLauncherButton extends LitElement {
   }
 
   async check() {
-    const res = await getIP();
-    if (!res || !res.success || res.error || !res.ip) {
+    const res = await getIP(this.reflectorHost, this.reflectorToken);
+    if (!res || res.error) {
       this.handleError(res)
+      return;
+    }
+
+    if (!res.ip) {
+      // No entry yet.
       return;
     }
 
@@ -71,7 +77,7 @@ class DogeboxLauncherButton extends LitElement {
     return html`
       <div class="action-wrap">
         <sl-tooltip content=${this._ready ? this._ip : "Dogebox IP unknown"}>
-          <sl-button size="large" href="http://${this._ip}" target="_blank" ?disabled=${!this._ready} variant="${this._ready ? "primary" : null }">Launch Dogebox</sl-button>
+          <sl-button size="large" href="http://${this._ip}:8080" target="_blank" ?disabled=${!this._ready} variant="${this._ready ? "primary" : null }">Launch Dogebox</sl-button>
         </sl-tooltip>
         <span class="side-text" href="http://${this._ip}">
           <text-loader .texts=${["Checking", "HOdL tight"]} ?loopEnd=${this._ready} endText="${this._ip}" loop></text-loader>

--- a/src/pages/page-recovery/index.js
+++ b/src/pages/page-recovery/index.js
@@ -5,6 +5,13 @@ import { notYet } from "/components/common/not-yet-implemented.js"
 import "/components/views/x-launcher-button/index.js";
 
 class SetupCompleteView extends LitElement {
+  static get properties() {
+    return {
+      reflectorHost: { type: String },
+      reflectorToken: { type: String },
+    }
+  }
+
   static styles = [
     themes,
     css`
@@ -77,7 +84,10 @@ class SetupCompleteView extends LitElement {
             password, key and connection.
           </p>
 
-          <x-launcher-button></x-launcher-button>
+          <x-launcher-button
+            .reflectorHost=${this.reflectorHost}
+            .reflectorToken=${this.reflectorToken}
+          ></x-launcher-button>
 
           <p>
             Need help? Visit

--- a/src/pages/page-recovery/index.js
+++ b/src/pages/page-recovery/index.js
@@ -8,7 +8,6 @@ class SetupCompleteView extends LitElement {
   static get properties() {
     return {
       isFirstTimeSetup: { type: Boolean },
-      reflectorHost: { type: String },
       reflectorToken: { type: String },
     }
   }
@@ -87,7 +86,6 @@ class SetupCompleteView extends LitElement {
           </p>
 
           <x-launcher-button
-            .reflectorHost=${this.reflectorHost}
             .reflectorToken=${this.reflectorToken}
           ></x-launcher-button>
 

--- a/src/pages/page-recovery/index.js
+++ b/src/pages/page-recovery/index.js
@@ -91,7 +91,7 @@ class SetupCompleteView extends LitElement {
 
           <p>
             Need help? Visit
-            <a href="https://setup.dogebox.net">setup.dogebox.net</a>
+            <a href="https://discord.gg/VEUMWpThg9">our discord</a>
           </p>
 
         </div>

--- a/src/pages/page-recovery/index.js
+++ b/src/pages/page-recovery/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { themes } from "/components/common/dynamic-form/themes.js";
 import { store } from "/state/store.js";
 import { notYet } from "/components/common/not-yet-implemented.js"
@@ -7,6 +7,7 @@ import "/components/views/x-launcher-button/index.js";
 class SetupCompleteView extends LitElement {
   static get properties() {
     return {
+      isFirstTimeSetup: { type: Boolean },
       reflectorHost: { type: String },
       reflectorToken: { type: String },
     }
@@ -70,6 +71,7 @@ class SetupCompleteView extends LitElement {
 
   render() {
     return html`
+      ${this.isFirstTimeSetup ? html`
       <div class="upper">
         <img class="hero" src="/static/img/celebrate.png" />
         <div class="actions">
@@ -100,15 +102,17 @@ class SetupCompleteView extends LitElement {
       <div class="center">
         <sl-divider></sl-divider>
       </div>
+      ` : nothing}
 
       <div class="lower">
+        ${this.isFirstTimeSetup ? html`
+          <h2>Recovery Actions</h2>
 
-        <h2>Recovery Actions</h2>
-
-        <p>
-          Insert your recovery USB at any time to perform the following
-          administrative actions
-        </p>
+          <p>
+            Insert your recovery USB at any time to perform the following
+            administrative actions
+          </p>
+        ` : nothing}
 
         <div class="actions gapped">
           <sl-button variant="neutral" outline data-id="network"

--- a/src/pages/page-recovery/index.js
+++ b/src/pages/page-recovery/index.js
@@ -65,8 +65,8 @@ class SetupCompleteView extends LitElement {
     `,
   ];
 
-  handleMgmtOptionClick(e) {
-    store.updateState({ setupContext: { view: e.currentTarget.getAttribute('data-id') }});
+  handleMgmtOptionClick(e, hideViewClose) {
+    store.updateState({ setupContext: { view: e.currentTarget.getAttribute('data-id'), hideViewClose: hideViewClose }});
   }
 
   render() {
@@ -123,7 +123,15 @@ class SetupCompleteView extends LitElement {
             @click=${this.handleMgmtOptionClick}>Change Password
           </sl-button>
 
-          <sl-button variant="neutral" outline data-id="factory-reset"
+          <sl-button variant="neutral" outline data-id="reboot"
+            @click=${(e) => this.handleMgmtOptionClick(e, true)}>Reboot
+          </sl-button>
+
+          <sl-button variant="neutral" outline data-id="power-off"
+            @click=${(e) => this.handleMgmtOptionClick(e, true)}>Power Off
+          </sl-button>
+
+          <sl-button variant="danger" outline data-id="factory-reset"
             @click=${notYet}>Factory Reset
           </sl-button>
         </div>

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -27,7 +27,7 @@ class Store {
       demoSystemPrompt: "",
       logStatsUpdates: false,
       logStateUpdates: false,
-      reflectorHost: `https://reflector.dogebox.org`
+      reflectorHost: `https://reflector.dogecoin.org`
     };
     this.pupContext = {
       computed: null,

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -27,6 +27,7 @@ class Store {
       demoSystemPrompt: "",
       logStatsUpdates: false,
       logStateUpdates: false,
+      reflectorHost: `https://reflector.dogebox.org`
     };
     this.pupContext = {
       computed: null,

--- a/src/utils/debug-settings.js
+++ b/src/utils/debug-settings.js
@@ -212,7 +212,7 @@ class DebugSettingsDialog extends LitElement {
             <sl-input
               type="text"
               name="wsApiBaseUrl"
-              help-text="Web Socket connections wii use this base URL"
+              help-text="Web Socket connections will use this base URL"
               value=${networkContext.wsApiBaseUrl}
               @sl-change=${this.handleInput}>
                 Web Socket Base URL
@@ -228,6 +228,18 @@ class DebugSettingsDialog extends LitElement {
                 Force Prompt by Name
             </sl-input>
           </div>
+
+          <div class="form-control">
+            <sl-input
+              type="text"
+              name="reflectorHost"
+              help-text="Override reflector host"
+              value="${networkContext.reflectorHost ?? "https://reflector.dogebox.org"}"
+              @sl-change=${this.handleInput}>
+              Override reflector host
+            </sl-input>
+          </div>
+
           <div class="form-control">
             <sl-button variant="warning" @click=${() => store.updateState({ networkContext: { token: "invalid-token-here" }})}>Invalidate Auth Token</sl-buton>
           </div>

--- a/src/utils/debug-settings.js
+++ b/src/utils/debug-settings.js
@@ -234,7 +234,7 @@ class DebugSettingsDialog extends LitElement {
               type="text"
               name="reflectorHost"
               help-text="Override reflector host"
-              value="${networkContext.reflectorHost ?? "https://reflector.dogebox.org"}"
+              value="${networkContext.reflectorHost ?? "https://reflector.dogecoin.org"}"
               @sl-change=${this.handleInput}>
               Override reflector host
             </sl-input>


### PR DESCRIPTION
This updates the recovery/setup flow to show a different UI if/once the user comes back into recovery mode post the initial setup experience. We don't care about the wizard steps normally in recovery, so we hide those and make it obvious we're in recovery mode.

This also hooks up the reflector during setup-mode, and post-setup shutdown & reboot buttons.

<img width="1060" alt="Screenshot 2024-09-30 at 11 19 25 PM" src="https://github.com/user-attachments/assets/e8af136c-19a7-4bed-9b43-d55cc4eb39cb">
