### PR TITLE
Display pup logos on details pages

### DIFF
--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -234,6 +234,8 @@ class PupPage extends LitElement {
     const short = pkg?.state?.manifest?.meta?.shortDescription || '';
     const long = pkg?.state?.manifest?.meta?.longDescription || ''
 
+    const logo = pkg?.assets?.logos?.mainLogoBase64
+
     // Exagerate the uninstallation time until reported correctly by dogeboxd.
     if (this._HARDCODED_UNINSTALL_WAIT_TIME) {
       // Temporarily force label to be uninstalling.
@@ -356,11 +358,14 @@ class PupPage extends LitElement {
 
     return html`
       <div id="PageWrapper" class="wrapper">
-        <section>
-          <div class="section-title">
-            <h3>Status</h3>
+        <section style="display: flex; flex-direction: row; gap: 1em;">
+          ${logo ? html`<img style="width: 91px; height: 91px;" src="${logo}" />` : nothing}
+          <div style="margin-bottom: 0em; width: 100%">
+            <div class="section-title">
+              <h3>Status</h3>
+            </div>
+            ${renderStatusAndActions()}
           </div>
-          ${renderStatusAndActions(labels)}
         </section>
 
         ${isRunning ? html`

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -240,10 +240,6 @@ class PupInstallPage extends LitElement {
       margin-bottom: 2em;
     }
 
-    section div {
-      margin-bottom: 1em;
-    }
-
     section .section-title {
       margin-bottom: 0em;
     }

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -19,12 +19,17 @@ export function renderStatus() {
   }
 
   return html`
-    <div class="section-title">
-      <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
-    </div>
-    <div>
-      <span class="status-label">${pkg.def.versions[pkg.def.latestVersion].meta.name}</span>
-      <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
+    <div style="display: flex; flex-direction: row; gap: 1em;">
+      ${pkg.def.logoBase64 ? html`<img style="width: 82px; height: 82px;" src="${pkg.def.logoBase64}" />` : nothing}
+      <div>
+        <div class="section-title">
+          <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
+        </div>
+        <div>
+          <span class="status-label">${pkg.def.versions[pkg.def.latestVersion].meta.name}</span>
+          <sl-progress-bar class="loading-bar" value="0" ?indeterminate=${isLoadingStatus}></sl-progress-bar>
+        </div>
+      </div>
     </div>
     <style>${styles}</style>
   `


### PR DESCRIPTION
<img width="630" alt="Screenshot 2024-10-02 at 3 42 17 PM" src="https://github.com/user-attachments/assets/b5423ecf-5bca-413d-a926-ce46bff88d01">
<img width="683" alt="Screenshot 2024-10-02 at 3 42 25 PM" src="https://github.com/user-attachments/assets/974dd846-b96c-43fe-8341-244985945e71">
