### PR TITLE
Misc UI fixes

### DIFF
--- a/src/pages/page-pup-library-listing/renders/actions.js
+++ b/src/pages/page-pup-library-listing/renders/actions.js
@@ -64,7 +64,9 @@ export function renderActions(labels) {
     }
   `
 
-  const uiButtons = pkg.state.webUIs.map((entry) => {
+  const webUIs = Array.isArray(pkg.state.webUIs) ? pkg.state.webUIs : []
+
+  const uiButtons = webUIs.map((entry) => {
     return html`
       <div style="display: flex; align-items: center;">
         <sl-button
@@ -82,7 +84,7 @@ export function renderActions(labels) {
     `
   })
 
-  const uiButtonsDiv = uiButtons.length > 0 ? html`
+  const uiButtonsDiv = installationId === 'ready' && statusId === 'running' && uiButtons.length > 0 ? html`
     <div style="display: flex; flex-wrap: wrap;gap: 1em;align-items: center; margin-top: 20px;">
       ${uiButtons}
     </div>

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -21,7 +21,7 @@ export function renderStatus() {
   return html`
     <div style="display: flex; flex-direction: row; gap: 1em;">
       ${pkg.def.logoBase64 ? html`<img style="width: 82px; height: 82px;" src="${pkg.def.logoBase64}" />` : nothing}
-      <div>
+      <div style="width: 100%;">
         <div class="section-title">
           <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
         </div>


### PR DESCRIPTION
<img width="602" alt="Screenshot 2024-10-02 at 4 24 41 PM" src="https://github.com/user-attachments/assets/5a625994-618e-42d5-8540-56ae4d0d88db">


The above still needs to be fixed, a pup with a logo that is uninstalled has buttons/actions pushed across. We can probably ignore if we want.