### PR TITLE
Handle broken pup states

### DIFF
--- a/src/pages/page-pup-library-listing/index.js
+++ b/src/pages/page-pup-library-listing/index.js
@@ -260,7 +260,7 @@ class PupPage extends LitElement {
 
     const renderStatusAndActions = () => {
       return html`
-        ${this.renderStatus(labels)}
+        ${this.renderStatus(labels, pkg)}
         <sl-progress-bar value="0" ?indeterminate=${isLoadingStatus || isInstallationLoadingStatus} class="loading-bar ${statusInstallationId}"></sl-progress-bar>
         ${this.renderActions(labels)}
       `

--- a/src/pages/page-pup-library-listing/renders/status.js
+++ b/src/pages/page-pup-library-listing/renders/status.js
@@ -1,6 +1,6 @@
 import { html, css, classMap, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
-export function renderStatus(labels) {
+export function renderStatus(labels, pkg) {
   let { statusId, statusLabel, installationId, installationLabel } = labels;
   const isInstallationLoadingStatus = ["uninstalling", "purging"].includes(installationId)
 
@@ -33,15 +33,65 @@ export function renderStatus(labels) {
     }
   `
 
-  return html`
+  const [ brokenReason, isRecoverable ] = getBrokenReason(pkg)
 
-    ${installationId === "uninstalled"
+  return html`
+    ${installationId === "uninstalled" || installationId === "broken"
       ? html`<span class="status-label ${installationId}">${installationLabel}</span>`
       : isInstallationLoadingStatus
         ? html`<span class="status-label ${installationId}">${installationLabel}</span>`
         : html`<span class="status-label ${statusId}">${statusLabel}</span>`
     }
 
+    ${installationId === "broken"
+      ? html`
+        <sl-alert variant="danger" open style="margin-top: 1em;">
+          <h3>${isRecoverable ?
+            "Please uninstall this pup and try again. If the issue persists, please join the Dogebox discord and ask for support." :
+            "There is an issue with this pup, unfortunately re-installing won't help in this case. Please reach out to the maintainers of this pup for support."}
+          </h3>
+
+          <br />
+          Error Message: ${brokenReason}<br />
+          Error Code: ${pkg.state.brokenReason}
+        </sl-alert>
+      `
+      : nothing
+    }
+
     <style>${styles}</style>
   `
 };
+
+/**
+ * Returns a pretty string to show to the user, and a boolean of whether this is a recoverable error or not.
+ * @returns {[string, boolean]}
+ */
+function getBrokenReason(pkg) {
+  switch(pkg.state.brokenReason) {
+    case "state_update_failed": {
+      return [ "We were unable to update the state for this pup.", true ]
+    }
+    case "download_failed": {
+      return [ "We were unable to download this pup.", true ]
+    }
+    case "nix_file_missing": {
+      return [ "We were unable to find the nix file for this pup.", false ]
+    }
+    case "nix_hash_mismatch": {
+      return [ "The pup manifest has an incorrect nix hash", false ]
+    }
+    case "delegate_key_write_failed": {
+      return [ "We were unable to write the delegate key for this pup.", true ]
+    }
+    case "enable_failed": {
+      return [ "We were unable to enable this pup.", true ]
+    }
+    case "nix_apply_failed": {
+      return [ "We were unable to build this pup.", false ]
+    }
+    default: {
+      return [ "An unknown error occurred.", true ]
+    }
+  }
+}

--- a/src/pages/page-pup-store-listing/index.js
+++ b/src/pages/page-pup-store-listing/index.js
@@ -148,9 +148,9 @@ class PupInstallPage extends LitElement {
         <section>
           <div class="section-title">
             <h3>About</h3>
-            <reveal-row style="margin-top:-1em;">
+            <reveal-row">
               ${long
-                ? html`<p>${long}</p>`
+                ? html`<p style="margin-top: -12px;>${long}</p>`
                 : html`<small style="font-family: 'Comic Neue'; color: var(--sl-color-neutral-600);">Such empty, no description.</small>`
               }
             </reveal-row>

--- a/src/pages/page-pup-store-listing/renders/actions.js
+++ b/src/pages/page-pup-store-listing/renders/actions.js
@@ -65,7 +65,18 @@ export function renderActions() {
             </sl-button>
           `
         : nothing}
-      ${isInstalled && installationId !== "installing"
+      ${installationId === "broken"
+        ? html`
+            <sl-button
+              variant="danger"
+              size="large"
+              href="${pkg.computed.libraryURL}"
+            >
+              View issue
+            </sl-button>
+          `
+      : nothing}
+      ${isInstalled && installationId !== "installing" && installationId !== "broken"
         ? html`
             <sl-button
               variant="primary"

--- a/src/pages/page-pup-store-listing/renders/status.js
+++ b/src/pages/page-pup-store-listing/renders/status.js
@@ -8,22 +8,31 @@ export function renderStatus() {
   const installationLabel = pkg?.computed?.installationLabel;
 
   const isInstalled = installationId === 'ready' && pkg.computed.isInstalled;
+  const isBroken = installationId === 'broken';
   const isLoadingStatus = ["installing"].includes(installationId);
 
   const normalisedLabel = () => {
-    if (!isInstalled) {
+    if (isBroken) {
+      return "Broken"
+    } else if (!isInstalled) {
       return "Not installed"
     } else {
       return "Installed"
     }
   }
 
+  const installationLabelClass = classMap({
+    "installed": isInstalled,
+    "not_installed": !isInstalled,
+    "broken": isBroken,
+  })
+
   return html`
     <div style="display: flex; flex-direction: row; gap: 1em;">
       ${pkg.def.logoBase64 ? html`<img style="width: 82px; height: 82px;" src="${pkg.def.logoBase64}" />` : nothing}
       <div style="width: 100%;">
         <div class="section-title">
-          <h3 class="installation-label ${isInstalled ? "installed" : "not_installed"}">${normalisedLabel()}</h3>
+          <h3 class="installation-label ${installationLabelClass}">${normalisedLabel()}</h3>
         </div>
         <div>
           <span class="status-label">${pkg.def.versions[pkg.def.latestVersion].meta.name}</span>


### PR DESCRIPTION
This properly handles the `Broken` pup state.

Relies on https://github.com/dogeorg/dogeboxd/pull/59

<img width="1551" alt="Screenshot 2024-10-06 at 10 33 02 AM" src="https://github.com/user-attachments/assets/a386c6ff-1c28-42eb-9150-a59ece4c2d2c">
