### PR TITLE
Metric UI enhancement (Max height + Copy to clipboard)

### DIFF
--- a/src/components/views/x-metric/metric.js
+++ b/src/components/views/x-metric/metric.js
@@ -34,8 +34,12 @@ class MetricView extends LitElement {
 
     return html`
       <sl-tooltip content="${this.metric.label}" placement="top-start" hoist>
-        <span class="label">${this.metric.label}</span>
+        <span class="label">
+          ${this.metric.label}
+          </span>
       </sl-tooltip>
+
+      <sl-copy-button class="copy" value="${this.metric.values}" @click=${(e) => e.stopPropagation()}></sl-copy-button>
 
       <div class="value-container">
       ${choose(type, [
@@ -69,12 +73,13 @@ class MetricView extends LitElement {
       value = '-'
     }
 
-    return html`<span>${value}</span>`
+    return html`<span class="string">${value}</span>`
   }
 
   static styles = css`
     :host {
       display: flex;
+      position: relative;
       flex-direction: column;
       align-items: start;
       border-radius: 4px;
@@ -85,6 +90,10 @@ class MetricView extends LitElement {
     }
     :host([expand]) {
       min-width: max-content;
+      padding-right: 40px;
+    }
+    :host(:hover) .copy {
+      visibility: visible;
     }
     .label {
       font-size: 0.8rem;
@@ -108,6 +117,37 @@ class MetricView extends LitElement {
       font-family: Monospace;
       font-weight: normal;
       font-size: 0.9rem;
+    }
+    .string {
+      position: relative;
+      display: inline-block;
+      max-width: 200px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-height: 2.9rem;
+      line-height: 1.1rem;
+
+      &::after {
+        content: "";
+        display: inline-block;
+        position: absolute;
+        bottom: 0px;
+        left: 0px;
+        width: 100%;
+        height: 4px;
+        background: linear-gradient(to bottom, transparent, #23252a);
+      }
+    }
+    .copy {
+      position: absolute;
+      visibility: hidden;
+      color: #555;
+      right: 3px;
+      top: 0px;
     }
   `
 }


### PR DESCRIPTION
Text stats lacked a vertical height clipping, text would bleed bellow the container.

This PR enhances the situation by:
1. Adding copy to clipboard button to all stats. Button is revealed on hover
2. Clips string metrics to 3 lines, blurring the 3rd line.

**Previously:** 
![image](https://github.com/user-attachments/assets/556afa4d-d820-4724-8c03-b4a88615b25e)


**Now with overflow handled:**
![image](https://github.com/user-attachments/assets/2fb9ee75-04c1-4d93-8dec-c281d12afc86)

**Copy in action:**
![copy-stat-to-clipboard](https://github.com/user-attachments/assets/6c7e7b6c-3da5-4db4-b16e-b8cc5d5ca7ca)
