### PR TITLE
Adjust disk warnings

### DIFF
--- a/src/components/views/action-select-install-location/index.js
+++ b/src/components/views/action-select-install-location/index.js
@@ -56,7 +56,7 @@ export class LocationPickerView extends LitElement {
 
   async fetchDisks() {
     this._allDisks = await getDisks();
-    this._installDisks = this._allDisks.filter(d => d.suitableInstallDrive);
+    this._installDisks = this._allDisks.filter(d => d?.suitability?.install?.usable);
     this._bootMediaDisk = this._allDisks.find(d => d.bootMedia);
     this._inflight_disks = false;
   }

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -236,8 +236,9 @@ class SystemSettings extends LitElement {
               value=${this._changes.disk}
               @sl-change=${this._handleDiskInputChange}
             >
-              ${this._disks.map(
-                (disk) =>
+              ${this._disks
+                .filter((disk) => disk.usable)
+                .map((disk) =>
                   html`
                     <sl-option value=${disk.name}>${disk.name} (${disk.sizePretty}) ${disk.bootMedia ? "[Running Dogebox OS]" : ""}</sl-option>
                   `,
@@ -246,7 +247,7 @@ class SystemSettings extends LitElement {
 
             <sl-alert variant="primary" ?open=${this._show_disk_size_warning} style="margin: 1em 0em;">
               <sl-icon slot="icon" name="info-circle"></sl-icon>
-              You have selected a disk with less than 300GB capacity.  You can proceed, however syncing the Blockchain will be prohibited as it will exhaust your disk.
+              You have selected a disk with less than 300GB capacity.  You can proceed, however syncing the Blockchain could exhaust your disk.
             </sl-alert>
           </div>
 

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -176,7 +176,7 @@ class SystemSettings extends LitElement {
     }
 
     this._is_boot_media = diskObject.bootMedia;
-    this._show_disk_size_warning = !diskObject.suitableDataDisk;
+    this._show_disk_size_warning = !diskObject?.suitability?.storage?.size;
   }
 
   handleCheckboxChange(e) {
@@ -237,7 +237,7 @@ class SystemSettings extends LitElement {
               @sl-change=${this._handleDiskInputChange}
             >
               ${this._disks
-                .filter((disk) => disk.usable)
+                .filter((disk) => disk?.suitability?.storage?.usable)
                 .map((disk) =>
                   html`
                     <sl-option value=${disk.name}>${disk.name} (${disk.sizePretty}) ${disk.bootMedia ? "[Running Dogebox OS]" : ""}</sl-option>

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -176,7 +176,7 @@ class SystemSettings extends LitElement {
     }
 
     this._is_boot_media = diskObject.bootMedia;
-    this._show_disk_size_warning = !diskObject?.suitability?.storage?.size;
+    this._show_disk_size_warning = !diskObject?.suitability?.storage?.sizeOK;
   }
 
   handleCheckboxChange(e) {

--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -231,7 +231,7 @@ class SystemSettings extends LitElement {
               required
               label="Select Mass Storage Disk"
               ?disabled=${this._inflight}
-              help-text="To sync the Dogecoin Blockchain, a disk with >200GB capacity is required"
+              help-text="To sync the Dogecoin Blockchain, a disk with >300GB capacity is required"
               data-field="disk"
               value=${this._changes.disk}
               @sl-change=${this._handleDiskInputChange}


### PR DESCRIPTION
- Filters out unusable disks from storage selector list
- Shows size warning where disk.suitability.storage.sizeOK is false
- Adjust messaging to encourage >300 Gb capacity rather than >200 (because blockchain is ~250 at present)
- Removes the "syncing prohibited" because its not actually prohibited, it will just exhaust disk