### PR TITLE
SSH key management

### DIFF
--- a/src/api/mocks.js
+++ b/src/api/mocks.js
@@ -37,7 +37,13 @@ import {
 import { postResponse as setHostname } from "./system/hostname.mocks.js";
 import { getResponse as checkForUpdates, postResponse as commenceUpdate } from "./system/updates.mocks.js";
 
-import { getSSHPublicKeysResponse } from "./sshkeys/sshkeys.mocks.js";
+import {
+  getSSHPublicKeysResponse,
+  deleteSSHPublicKeyResponse,
+  addSSHPublicKeyResponse,
+  updateSSHStateResponse,
+  getSSHStateResponse,
+} from "./sshkeys/sshkeys.mocks.js";
 
 export const mocks = [
   storeListingMock,
@@ -68,5 +74,9 @@ export const mocks = [
   setHostname,
   checkForUpdates,
   commenceUpdate,
-  getSSHPublicKeysResponse
+  getSSHPublicKeysResponse,
+  deleteSSHPublicKeyResponse,
+  addSSHPublicKeyResponse,
+  updateSSHStateResponse,
+  getSSHStateResponse
 ];

--- a/src/api/mocks.js
+++ b/src/api/mocks.js
@@ -37,6 +37,8 @@ import {
 import { postResponse as setHostname } from "./system/hostname.mocks.js";
 import { getResponse as checkForUpdates, postResponse as commenceUpdate } from "./system/updates.mocks.js";
 
+import { getSSHPublicKeysResponse } from "./sshkeys/sshkeys.mocks.js";
+
 export const mocks = [
   storeListingMock,
   bootstrapV2Mocks,
@@ -65,5 +67,6 @@ export const mocks = [
   setKeymap,
   setHostname,
   checkForUpdates,
-  commenceUpdate
+  commenceUpdate,
+  getSSHPublicKeysResponse
 ];

--- a/src/api/sshkeys/sshkeys.js
+++ b/src/api/sshkeys/sshkeys.js
@@ -1,0 +1,11 @@
+import ApiClient from "/api/client.js";
+import { store } from "/state/store.js";
+
+import { getSSHPublicKeysResponse } from "./sshkeys.mocks.js";
+
+const client = new ApiClient(store.networkContext.apiBaseUrl);
+
+export async function getSSHPublicKeys() {
+  const res = await client.get(`/system/ssh/keys`, { mock: getSSHPublicKeysResponse });
+  return res;
+}

--- a/src/api/sshkeys/sshkeys.js
+++ b/src/api/sshkeys/sshkeys.js
@@ -1,11 +1,37 @@
 import ApiClient from "/api/client.js";
 import { store } from "/state/store.js";
 
-import { getSSHPublicKeysResponse } from "./sshkeys.mocks.js";
+import {
+  getSSHPublicKeysResponse,
+  deleteSSHPublicKeyResponse,
+  addSSHPublicKeyResponse,
+  updateSSHStateResponse,
+  getSSHStateResponse
+} from "./sshkeys.mocks.js";
 
 const client = new ApiClient(store.networkContext.apiBaseUrl);
 
 export async function getSSHPublicKeys() {
   const res = await client.get(`/system/ssh/keys`, { mock: getSSHPublicKeysResponse });
+  return res;
+}
+
+export async function deleteSSHPublicKey(id) {
+  const res = await client.delete(`/system/ssh/key/${id}`, { mock: deleteSSHPublicKeyResponse });
+  return res;
+}
+
+export async function addSSHPublicKey(key) {
+  const res = await client.put(`/system/ssh/key`, { key }, { mock: addSSHPublicKeyResponse });
+  return res;
+}
+
+export async function setSSHState(state) {
+  const res = await client.put(`/system/ssh/state`, { ...state }, { mock: updateSSHStateResponse });
+  return res;
+}
+
+export async function getSSHState(state) {
+  const res = await client.get(`/system/ssh/state`, { mock: getSSHStateResponse });
   return res;
 }

--- a/src/api/sshkeys/sshkeys.mocks.js
+++ b/src/api/sshkeys/sshkeys.mocks.js
@@ -1,0 +1,9 @@
+export const getSSHPublicKeysResponse = {
+  name: "/system/ssh/keys",
+  group: "SSH",
+  method: "get",
+  res: {
+    success: true,
+    keys: [{ key: "flibble-wibble-mocked-response", id: "ABC123" }],
+  }
+};

--- a/src/api/sshkeys/sshkeys.mocks.js
+++ b/src/api/sshkeys/sshkeys.mocks.js
@@ -4,6 +4,59 @@ export const getSSHPublicKeysResponse = {
   method: "get",
   res: {
     success: true,
-    keys: [{ key: "flibble-wibble-mocked-response", id: "ABC123" }],
+    keys: [
+      {
+        dateAdded: "2024-12-03T15:04:05.123456789Z",
+        key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDFt8vWZ9D2SePDzF6eS8T2KDP2q9vVHpf9HKx9IU8vB4UHN5V5Up7U3SEQVHKEp4DtRVVptYHqq2MmB2SyGCERr6+z5mZxy+7zLlzKTcW+gMP4M7iLvg5AaWjx0gUDxE1zjcTYa0Vd8M7K8JwsjLq9ExwL+cAv8TzlsqzF5UNw/Xc8",
+        id: "XYZ789"
+      },
+      {
+        dateAdded: "2024-11-27T07:30:22.987654321Z",
+        key: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHEOLLbeZr1DtUHJ/J7jOsCPtBE6KZVPk0LR4memYWK",
+        id: "DEF456"
+      },
+      {
+        dateAdded: "2023-06-03T23:59:59.234567890Z",
+        key: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJnNlh8kzYX9xww4hPuTsGQMqA9T4bwGxXXzPVHZz6ROCS8OL6bJ6UF1Qe/bsG4j7KHFZJD8usdHSgztnxQOyXM=",
+        id: "MNO123"
+      }
+    ],
   }
 };
+
+export const deleteSSHPublicKeyResponse = {
+  name: "/system/ssh/key/:id",
+  group: "SSH",
+  method: "delete",
+  res: {
+    success: true,
+  }
+}
+
+export const addSSHPublicKeyResponse = {
+  name: "/system/ssh/key",
+  group: "SSH",
+  method: "put",
+  res: {
+    success: true,
+  }
+}
+
+export const updateSSHStateResponse = {
+  name: "/system/ssh/state",
+  group: "SSH",
+  method: "put",
+  res: {
+    success: true,
+  }
+}
+
+export const getSSHStateResponse = {
+  name: "/system/ssh/state",
+  group: "SSH",
+  method: "get",
+  res: {
+    success: true,
+    enabled: true
+  }
+}

--- a/src/components/views/action-remote-access/index.js
+++ b/src/components/views/action-remote-access/index.js
@@ -1,0 +1,67 @@
+import {
+  LitElement,
+  html,
+  css,
+  nothing,
+} from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+
+import { getSSHPublicKeys } from "/api/sshkeys/sshkeys.js";
+
+export class RemoteAccessSettings extends LitElement {
+  static get properties() {
+    return {
+      _loading: { type: Boolean},
+      _server_fault: { type: String },
+      _ssh_public_keys: { type: Array },
+    }
+  }
+
+  static styles = css`
+    h1 {
+      font-family: "Comic Neue", sans-serif;
+      text-align: center;
+    }
+  `
+
+  constructor() {
+    super();
+    this._ssh_public_keys = [];
+    this._server_fault = "";
+  }
+
+  firstUpdated() {
+    this.fetchSSHPublicKeys();
+  }
+
+  async fetchSSHPublicKeys() {
+    // spinner start
+    this._loading = true;
+    try {
+      this._ssh_public_keys = await getSSHPublicKeys();
+    } catch (err) {
+      // failed to fetch keys
+      this._server_fault = err.message;
+      console.log('ER', err);
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  render() {
+    const hasKeys = this._ssh_public_keys.length
+    const keys = this._ssh_public_keys 
+    return html`
+      <h1>Remote Access</h1>
+
+      <sl-button variant="text">Add key</sl-button>
+      
+      ${hasKeys ? keys.map((k) => {
+        return html`<code data-id="${k.id}">${k.key}</code>`
+      }) : nothing }
+
+      <sl-textarea name="ssh-key"></sl-textarea>
+    `
+  }
+}
+
+customElements.define('x-action-remote-access', RemoteAccessSettings);

--- a/src/components/views/action-remote-access/index.js
+++ b/src/components/views/action-remote-access/index.js
@@ -5,39 +5,141 @@ import {
   nothing,
 } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
-import { getSSHPublicKeys } from "/api/sshkeys/sshkeys.js";
+import {
+  getSSHPublicKeys,
+  deleteSSHPublicKey,
+  addSSHPublicKey,
+  getSSHState,
+  setSSHState,
+} from "/api/sshkeys/sshkeys.js";
+import "/components/common/action-row/action-row.js";
+import { asyncTimeout } from "/utils/timeout.js";
+import { createAlert } from "/components/common/alert.js";
 
 export class RemoteAccessSettings extends LitElement {
   static get properties() {
     return {
       _loading: { type: Boolean},
+      _inflight: { type: Boolean },
       _server_fault: { type: String },
       _ssh_public_keys: { type: Array },
+      _expanded_key: { type: String },
+      _show_add_key_dialog: { type: Boolean },
+      _selected_key_id_for_trash: { type: String },
+      _show_private_key_warning: { type: Boolean },
+      _new_key_value: { type: String },
+      _ssh_state: { type: Object },
     }
   }
 
   static styles = css`
     h1 {
+      display: block;
       font-family: "Comic Neue", sans-serif;
       text-align: center;
+      margin-bottom: .4rem;
     }
+
+    p {
+      text-align: center;
+      line-height: 1.4;
+    }
+
+    .actions {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      margin-top: 1em;
+
+      sl-button {
+        margin-right: -1em;
+      }
+    }
+
+    .key-reveal-dropdown {
+      font-size: 0.8rem;
+      background: rgba(0,0,0,0.2);
+      word-break: break-all;
+      margin-left: 48px;
+      padding: 1em;
+      border-radius: 8px;
+    }
+
+    .key-actions {
+      margin-left: 48px;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: flex-end;
+    }
+
+    .form-control {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      margin: 1em 0em;
+    }
+
+    .loading-list, .empty-list {
+      height: 180px;
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+      color: #555555;
+      font-family: 'Comic Neue';
+    }
+
+    .confirmation-container {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: center;
+      gap: 1em;
+    }
+
   `
 
   constructor() {
     super();
     this._ssh_public_keys = [];
+    this._expanded_key = "";
     this._server_fault = "";
+    this._new_key_value = "";
+    this._ssh_state = {};
   }
 
   firstUpdated() {
+    this.fetchSSHState();
     this.fetchSSHPublicKeys();
+  }
+
+  async fetchSSHState() {
+    this._inflight_state_fetch = true;
+    try {
+      const res = await getSSHState();
+      if (res) {
+        this._ssh_state = res;
+      }
+    } catch (err) {
+      createAlert('warning', 'Failed to fetch SSH state');
+    } finally {
+      this._inflight_state_fetch = false;
+    }
   }
 
   async fetchSSHPublicKeys() {
     // spinner start
     this._loading = true;
+
+    await asyncTimeout(1000);
+
     try {
-      this._ssh_public_keys = await getSSHPublicKeys();
+      const res = await getSSHPublicKeys();
+      if (res.keys) {
+        this._ssh_public_keys = res.keys
+      }
     } catch (err) {
       // failed to fetch keys
       this._server_fault = err.message;
@@ -47,21 +149,155 @@ export class RemoteAccessSettings extends LitElement {
     }
   }
 
+  handleExpand(keyId) {
+    this._expanded_key = keyId
+  }
+
+  handleAddClick() {
+    this._show_add_key_dialog = true
+  }
+
+  handleTrash(keyId) {
+    this._selected_key_id_for_trash = keyId;
+  }
+
+  async performAddKey() {
+    this._inflight = true;
+    await asyncTimeout(1000);
+    try {
+      const res = await addSSHPublicKey(this._new_key_value.trim())
+      await asyncTimeout(2000);
+      this._inflight = false;
+      this._show_add_key_dialog = false;
+      this._new_key_value = "";
+    } catch (err) {
+      createAlert('danger', 'Failed to add SSH key');
+    } finally {
+      this.fetchSSHPublicKeys();
+    }
+  }
+
+  async performKeyDelete() {
+    this._inflight = true;
+    await asyncTimeout(1000);
+    try {
+      const res = await deleteSSHPublicKey(this._selected_key_id_for_trash)
+      await asyncTimeout(2000);
+      this._selected_key_id_for_trash = "";
+      this._inflight = false;
+    } catch (err) {
+      createAlert('danger', 'Failed to delete SSH key');
+    } finally {
+      this.fetchSSHPublicKeys();
+    }
+  }
+
+  handleTextareaInput(e) {
+    const inputValue = e.target.value;
+    this._new_key_value = inputValue;
+    this._show_private_key_warning = privateKeyIndicators.some(indicator =>
+      inputValue.includes(indicator)
+    );
+  }
+
+  async handleSSHToggle(e) {
+    try {
+      await setSSHState({ enabled: e.target.checked });
+    } catch (err) {
+      createAlert('danger', 'Failed to change SSH state');
+    }
+  }
+
   render() {
     const hasKeys = this._ssh_public_keys.length
     const keys = this._ssh_public_keys 
     return html`
       <h1>Remote Access</h1>
 
-      <sl-button variant="text">Add key</sl-button>
+      <div class="form-control">
+        <sl-switch @sl-change=${this.handleSSHToggle} ?checked=${this._ssh_state.enabled} help-text="Allows your Dogebox to be accessed via SSH.">Enable SSH Service</sl-switch>
+      </div>
       
-      ${hasKeys ? keys.map((k) => {
-        return html`<code data-id="${k.id}">${k.key}</code>`
-      }) : nothing }
+      <div class="actions">
+        <strong>SSH keys</strong>
+        <sl-button
+          ?disabled=${this._loading || this._inflight}
+          variant="text"
+          class="pull-right"
+          @click=${this.handleAddClick}>
+          + Add key
+        </sl-button>
+      </div>
 
-      <sl-textarea name="ssh-key"></sl-textarea>
+      ${this._loading ? html`
+        <div class="loading-list">
+          <sl-spinner style="--indicator-color:#777;"></sl-spinner>
+        </div>
+      ` : nothing }
+
+      ${!hasKeys && !this._loading && !this._inflight ? html`
+        <div class="empty-list">
+          <p>No keys here.</p>
+        </div>
+      ` : nothing }
+
+      <div class="list">
+      ${!this._loading && hasKeys ? keys.map((k) => {
+        return html`
+        <action-row
+          expandable
+          ?expand=${this._expanded_key === k.id}
+          @row-expand=${() => this.handleExpand(k.id)}
+          prefix="key"
+          label="${k.key.substring(0, 32)}..."
+        >
+          Added: <sl-format-date month="long" day="numeric" year="numeric" date="${k.dateAdded}"></sl-format-date>
+          <div slot="hidden">
+            <div class="key-reveal-dropdown">${k.key}</div>
+            <div class="key-actions">
+              <sl-copy-button hoist value=${k.key}></sl-copy-button>
+              <sl-icon-button name="trash-fill" label="Trash" @click=${() => this.handleTrash(k.id)}></sl-icon-button>
+            </div>
+          </div>
+        </action-row>`
+      }) : nothing }
+      </div>
+
+      <sl-dialog @sl-request-close=${(e) => { this._selected_key_id_for_trash = ""; e.stopPropagation();}} ?open=${this._selected_key_id_for_trash} label="Are you sure?">
+        <div class="confirmation-container">
+          <sl-button variant="text" @click=${() => this._selected_key_id_for_trash = ""}>I changed my mind</sl-button>
+          <sl-button variant="danger" ?loading=${this._inflight} @click=${this.performKeyDelete}>Yes, delete this SSH Public Key</sl-button>
+        </div>
+      </sl-dialog>
+
+      <sl-dialog @sl-request-close=${(e) => { this._show_add_key_dialog = false; e.stopPropagation(); }} ?open=${this._show_add_key_dialog} label="Add an SSH Public Key">
+        <sl-textarea
+          value=${this._new_key_value}
+          rows="6"
+          help-text="Important: Enter your public key"
+          @sl-input=${this.handleTextareaInput}
+          >
+        </sl-textarea>
+
+        <sl-alert variant="warning" ?open=${this._show_private_key_warning} style="margin-top: 1em;">
+          Take care, you may have mistakenly entered a Private key.<br>Be sure to enter a Public key only.
+        </sl-alert>
+
+        <div slot="footer">
+          <sl-button variant="text" @click=${() => this._show_add_key_dialog = false}>I've changed my mind</sl-button>
+          <sl-button variant="primary" ?disabled=${this._inflight || this._show_private_key_warning || !this._new_key_value} ?loading=${this._inflight} @click=${this.performAddKey}>Submit</sl-button>
+        </div>
+      </sl-dialog>
     `
   }
 }
+
+const privateKeyIndicators = [
+  '-----BEGIN PRIVATE KEY-----',
+  '-----BEGIN RSA PRIVATE KEY-----',
+  '-----BEGIN OPENSSH PRIVATE KEY-----',
+  '-----BEGIN EC PRIVATE KEY-----',
+  '-----BEGIN DSA PRIVATE KEY-----'
+];
 
 customElements.define('x-action-remote-access', RemoteAccessSettings);

--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -6,6 +6,7 @@ import {
 } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import "/components/common/action-row/action-row.js";
 import "/components/views/action-check-updates/index.js";
+import "/components/views/action-remote-access/index.js";
 import { notYet } from "/components/common/not-yet-implemented.js";
 import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
@@ -52,7 +53,7 @@ class SettingsPage extends LitElement {
   render() {
     const { updateAvailable } = store.getContext('sys')
     const dialog = store.getContext('dialog')
-    const hasSettingsDialog = ["updates", "versions"].includes(dialog.name);
+    const hasSettingsDialog = ["updates", "versions", "remote-access"].includes(dialog.name);
     return html`
       <div class="padded">
         <section>
@@ -68,6 +69,9 @@ class SettingsPage extends LitElement {
             </action-row>
             <action-row prefix="wifi" label="Wifi" @click=${notYet}>
               Add or remove Wifi networks
+            </action-row>
+            <action-row prefix="key" label="Remote Access" href="/settings/remote-access">
+              Manage SSH settings and keys
             </action-row>
           <div class="list-wrap">
         </section>
@@ -90,7 +94,8 @@ class SettingsPage extends LitElement {
         ?open=${hasSettingsDialog} @sl-request-close=${this.handleDialogClose}>
         ${choose(dialog.name, [
           ["updates", () => html`<x-action-check-updates></x-action-check-updates>`],
-          ["versions", () => renderVersionsDialog(store, this.handleDialogClose)]
+          ["remote-access", () => html`<x-action-remote-access></x-action-remote-access>`],
+          ["versions", () => renderVersionsDialog(store, this.handleDialogClose)],
         ])}
       </sl-dialog>
     `;


### PR DESCRIPTION
Adds SSH service and key management

- Can LIST all keys
- Can ADD a key
- Can DELETE a key
- Can COPY to clipboard
- Can TOGGLE SSH service 

Additionally:
- Provides some alerts if any of the network requests fail
- Checks the user input for common PRIVATE key indicators, hopefully helping users avoiding making a blunder

**Fly though:**
![ssh-manage-keys](https://github.com/user-attachments/assets/c93f66ef-13a6-4bad-a698-40fe642513b6)
