### PR TITLE
Recovery mode fix

### DIFF
--- a/src/app_recovery.js
+++ b/src/app_recovery.js
@@ -124,7 +124,6 @@ class AppModeApp extends LitElement {
   _determineStartingStep(setupState) {
     const {
       hasCompletedInitialConfiguration,
-      hasConfiguredStorageLocation,
       hasGeneratedKey,
       hasConfiguredNetwork,
       isForbidden,
@@ -148,12 +147,8 @@ class AppModeApp extends LitElement {
       return STEP_LOGIN;
     }
 
-    if (!hasConfiguredStorageLocation) {
-      return STEP_INTRO;
-    }
-
     if (!hasGeneratedKey) {
-      return STEP_SET_PASSWORD;
+      return STEP_INTRO;
     }
 
     if (!hasConfiguredNetwork) {

--- a/src/components/common/not-yet-implemented.js
+++ b/src/components/common/not-yet-implemented.js
@@ -1,8 +1,8 @@
 import { html, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 
 export function notYet(event) {
-  event.preventDefault();
-  event.stopPropagation();
+  event && event.preventDefault && event.preventDefault();
+  event && event.stopPropagation && event.stopPropagation();
 
   if (!document.body.hasAttribute('listener-on-not-yet-dialog')) {
     document.body.addEventListener('sl-after-hide', closeNotYetDialog);

--- a/src/components/layouts/standard/renders/nav.js
+++ b/src/components/layouts/standard/renders/nav.js
@@ -36,11 +36,7 @@ export function renderNav(CURPATH) {
               Explore
             </a>
 
-            <a href="/stats" @click="${(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              notYet();
-            }}" class="menu-item ${CURPATH.startsWith("/stats") ? "active" : ""}">
+            <a href="/stats" @click="${notYet}" class="menu-item ${CURPATH.startsWith("/stats") ? "active" : ""}">
               <sl-icon name="heart-pulse-fill"></sl-icon>
               Monitor
             </a>


### PR DESCRIPTION
After successful install and dogebox usage, user could not enter recovery mode without being prompted to re-select their storage.  This is because dpanel had a reference to a not yet implemented setup fact.

Additionally, this PR adds some guards to the notYetImplemented component.  It should only call preventDef and stopProp if an event is passed to it and those methods exist.