### PR TITLE
Fix hostname not getting persisted

### DIFF
--- a/src/components/views/action-system-settings/index.js
+++ b/src/components/views/action-system-settings/index.js
@@ -154,8 +154,13 @@ class SystemSettings extends LitElement {
 
   _generateName() {
     const rando = Math.round(Math.random() * 1000);
-    this._changes['device-name'] = `my_dogebox_${rando}`;
+    this._changes["device-name"] = `my-dogebox-${rando}`;
     this.requestUpdate();
+  }
+
+  _handleInputChange(e) {
+    const field = e.target.getAttribute("data-field");
+    this._changes[field] = e.target.value;
   }
 
   _handleKeymapInputChange(e) {


### PR DESCRIPTION
The change handler for hostname was not implemented. Added one that's a copy of the keymap handler.

Changed the name generator to not use `_` as they're [not allowed in hostName](https://mynixos.com/nixpkgs/option/networking.hostName) (even though the regex is wrong there)