### PR TITLE
Removed monitor item from navigation menu

### DIFF
--- a/src/components/layouts/standard/renders/nav.js
+++ b/src/components/layouts/standard/renders/nav.js
@@ -36,11 +36,6 @@ export function renderNav(CURPATH) {
               Explore
             </a>
 
-            <a href="/stats" @click="${notYet}" class="menu-item ${CURPATH.startsWith("/stats") ? "active" : ""}">
-              <sl-icon name="heart-pulse-fill"></sl-icon>
-              Monitor
-            </a>
-
             <a href="/settings" class="menu-item ${CURPATH.startsWith("/settings") ? "active" : ""}">
               <sl-icon name="sliders"></sl-icon>
               Settings


### PR DESCRIPTION
The monitor page may not be implemented for a while, removing it for now to create a neater menu