### PR TITLE
Activity log should always align it's text to the left of it's window

### DIFF
--- a/src/components/views/x-activity-log.js
+++ b/src/components/views/x-activity-log.js
@@ -153,6 +153,7 @@ class ActivityLog extends LitElement {
         overflow-y: scroll;
         overflow-x: hidden;
         box-sizing: border-box;
+        text-align: left;
       }
 
       div#LogFooter {
@@ -185,6 +186,7 @@ class ActivityLog extends LitElement {
         font-weight: bold;
         margin: 0px 0;
         padding: 0px;
+        text-align: left;
       }
     `;
   }


### PR DESCRIPTION
Small change to ensure text is aligned left within the activity log, otherwise it could end up center or right unintentionally:

 
![image](https://github.com/user-attachments/assets/6505e0ed-f31e-46ac-88ee-1b1cafc81d9f)
