### PR TITLE
Enable 'Select Network' settings panel

### DIFF
--- a/src/components/views/action-select-network/index.js
+++ b/src/components/views/action-select-network/index.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
+import { LitElement, html, css, nothing } from "/vendor/@lit/all@3.1.2/lit-all.min.js";
 import { getNetworks } from "/api/network/get-networks.js";
 import { putNetwork } from "/api/network/set-network.js";
 import { postSetupBootstrap } from "/api/system/post-bootstrap.js";
@@ -38,6 +38,7 @@ class SelectNetwork extends LitElement {
   static get properties() {
     return {
       showSuccessAlert: { type: Boolean },
+      showRecoveryOptions: { type: Boolean },
       reflectorToken: { type: String },
       _server_fault: { type: Boolean },
       _invalid_creds: { type: Boolean },
@@ -55,6 +56,7 @@ class SelectNetwork extends LitElement {
     this._setNetworkFields = {};
     this._setNetworkValues = {};
     this._networks = [];
+    this.showRecoveryOptions = true;
 
     // Set initial fields
     this.updateSetNetworkFields();
@@ -75,68 +77,74 @@ class SelectNetwork extends LitElement {
   }
 
   updateSetNetworkFields() {
+    const fields = [
+      {
+        name: "network",
+        label: "Select Network",
+        labelAction: { name: "refresh", label: "Refresh" },
+        type: "select",
+        required: true,
+        options: this._networks
+      },
+      {
+        name: "network-ssid",
+        label: "Network SSID",
+        type: "text",
+        required: true,
+        revealOn: (state) => state.network?.value == "hidden"
+      },
+      {
+        name: "network-encryption",
+        label: "Network Encryption",
+        type: "select",
+        required: true,
+        revealOn: (state) => state.network?.value === 'hidden',
+        options: [
+          { value: 'wep', label: 'WEP' },
+          { value: 'wpa', label: 'WPA' },
+          { value: 'wpa2-psk', label: 'WPA2 Personal' },
+          { value: 'none', label: 'None' },
+        ]
+      },
+      {
+        name: "network-pass",
+        label: "Network Password",
+        type: "password",
+        required: true,
+        passwordToggle: true,
+        revealOn: (state) => {
+          // If the selected network is a broadcast wifi network with encryption, show.
+          if (state.network?.encryption) return true
+
+          // If we've selected a hidden wifi network, _and_ configured the encryption to be NOT none, show.
+          if (state.network?.value === 'hidden') {
+            if (state['network-encryption'] && state['network-encryption'].value !== 'none') {
+              return true
+            }
+          }
+
+          return false
+        }
+      }
+    ];
+
+    // Only add SSH key field if showRecoveryOptions is true
+    if (this.showRecoveryOptions) {
+      fields.push({
+        name: "ssh-key",
+        label: "SSH Key (Optional)",
+        type: "text",
+        required: false,
+        placeholder: "Pasting an SSH key here will also enable SSH"
+      });
+    }
+
     this._setNetworkFields = {
       sections: [
         {
           name: "select-network",
           submitLabel: "Much Connect",
-          fields: [
-            {
-              name: "network",
-              label: "Select Network",
-              labelAction: { name: "refresh", label: "Refresh" },
-              type: "select",
-              required: true,
-              options: this._networks
-            },
-            {
-              name: "network-ssid",
-              label: "Network SSID",
-              type: "text",
-              required: true,
-              revealOn: (state) => state.network?.value == "hidden"
-            },
-            {
-              name: "network-encryption",
-              label: "Network Encryption",
-              type: "select",
-              required: true,
-              revealOn: (state) => state.network?.value === 'hidden',
-              options: [
-                { value: 'wep', label: 'WEP' },
-                { value: 'wpa', label: 'WPA' },
-                { value: 'wpa2-psk', label: 'WPA2 Personal' },
-                { value: 'none', label: 'None' },
-              ]
-            },
-            {
-              name: "network-pass",
-              label: "Network Password",
-              type: "password",
-              required: true,
-              passwordToggle: true,
-              revealOn: (state) => {
-                // If the selected network is a broadcast wifi network with encryption, show.
-                if (state.network?.encryption) return true
-
-                // If we've selected a hidden wifi network, _and_ configured the encryption to be NOT none, show.
-                if (state.network?.value === 'hidden') {
-                  if (state['network-encryption'] && state['network-encryption'].value !== 'none') {
-                    return true
-                  }
-                }
-
-                return false
-              }
-            },
-            {
-              name: "ssh-key",
-              label: "SSH Key (Optional)",
-              type: "text",
-              required: false,
-              placeholder: "Pasting an SSH key here will also enable SSH"
-            }
-          ],
+          fields: fields
         },
       ],
     };
@@ -331,12 +339,14 @@ class SelectNetwork extends LitElement {
             </dynamic-form>
             `: nothing }
 
-            <div style="margin: 2em 8px">
-              <sl-alert variant="warning" open>
-                <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
-                After you hit connect it may take up to 10 minutes while your Dogebox is configured!
-              </sl-alert>
-            </div>
+            ${this.showRecoveryOptions ? html`
+              <div style="margin: 2em 8px">
+                <sl-alert variant="warning" open>
+                  <sl-icon slot="icon" name="exclamation-triangle"></sl-icon>
+                  After you hit connect it may take up to 10 minutes while your Dogebox is configured!
+                </sl-alert>
+              </div>
+            ` : nothing}
         </div>
       </div>
     `;

--- a/src/pages/page-settings/index.js
+++ b/src/pages/page-settings/index.js
@@ -7,6 +7,7 @@ import {
 import "/components/common/action-row/action-row.js";
 import "/components/views/action-check-updates/index.js";
 import "/components/views/action-remote-access/index.js";
+import "/components/views/action-select-network/index.js";
 import { notYet } from "/components/common/not-yet-implemented.js";
 import { store } from "/state/store.js";
 import { StoreSubscriber } from "/state/subscribe.js";
@@ -45,6 +46,13 @@ class SettingsPage extends LitElement {
     this.context = new StoreSubscriber(this, store);
   }
 
+  handleSelectNetwork(e) {
+    e.preventDefault();
+    store.updateState({ dialogContext: { name: 'select-network' }});
+    const router = getRouter();
+    router.go('/settings/select-network', { replace: true });
+  }
+
   handleDialogClose() {
     store.updateState({ dialogContext: { name: null }});
     const router = getRouter();
@@ -54,7 +62,7 @@ class SettingsPage extends LitElement {
   render() {
     const { updateAvailable } = store.getContext('sys')
     const dialog = store.getContext('dialog')
-    const hasSettingsDialog = ["updates", "versions", "remote-access"].includes(dialog.name);
+    const hasSettingsDialog = ["updates", "versions", "remote-access", "select-network"].includes(dialog.name);
     return html`
       <div class="padded">
         <section>
@@ -68,8 +76,8 @@ class SettingsPage extends LitElement {
             <action-row prefix="arrow-repeat" ?dot=${updateAvailable} label="Updates" href="/settings/updates" @click=${notYet}>
               Check for updates
             </action-row>
-            <action-row prefix="wifi" label="Wifi" @click=${notYet}>
-              Add or remove Wifi networks
+            <action-row prefix="wifi" label="Select Network" href="/settings/select-network" @click=${this.handleSelectNetwork}>
+              Select a network to connect to
             </action-row>
             <action-row prefix="key" label="Remote Access" href="/settings/remote-access" @click=${notYet}>
               Manage SSH settings and keys
@@ -96,6 +104,7 @@ class SettingsPage extends LitElement {
         ${choose(dialog.name, [
           ["updates", () => html`<x-action-check-updates></x-action-check-updates>`],
           ["remote-access", () => html`<x-action-remote-access></x-action-remote-access>`],
+          ["select-network", () => html`<x-action-select-network .showRecoveryOptions=${false}></x-action-select-network>`],
           ["versions", () => renderVersionsDialog(store, this.handleDialogClose)],
         ])}
       </sl-dialog>


### PR DESCRIPTION
Draft PR ready for enabling network selection in the settings menu.

Have re-used the network selection view from the configuration process, and hidden some elements when we're not in recovery
![image](https://github.com/user-attachments/assets/f378acce-a1d5-4ee8-b35d-d71127b00672)

Terminology also updated from 'wifi' to 'select network' as this is not exclusive to wifi networks
![image](https://github.com/user-attachments/assets/cb04a00f-ca08-488a-ac88-9aba522f0a21)
