### PR TITLE
Wi-Fi signal strength icons

### DIFF
--- a/src/api/network/get-networks.mocks.js
+++ b/src/api/network/get-networks.mocks.js
@@ -14,11 +14,27 @@ export const getResponse = {
           {
             ssid: "DogeBox",
             bssid: "AA:AA:AA:AA:AA:AA:AA:AA",
-            encryption: "WPA2"
+            encryption: "WPA2",
+            quality: 0.85,
+            signal: "-45dBm"
           },
           {
             ssid: "Open Network",
             bssid: "BB:BB:BB:BB:BB:BB:BB:BB",
+            quality: 0.80,
+            signal: "-55dBm"
+          },
+          {
+            ssid: "Fair Signal Network",
+            bssid: "CC:CC:CC:CC:CC:CC:CC:CC",
+            quality: 0.50,
+            signal: "-65dBm"
+          },
+          {
+            ssid: "Poor Signal Network",
+            bssid: "DD:DD:DD:DD:DD:DD:DD:DD",
+            quality: 0.25,
+            signal: "-75dBm"
           }
         ]
       }


### PR DESCRIPTION
Wi-Fi signal strength and quality are now available from the backend.
Added icons from shoelace to differentiate between ethernet and Wi-Fi, with the Wi-Fi icons indicating signal strength.

![image](https://github.com/user-attachments/assets/ee4bfce9-2746-48cb-b42d-bc600a2a83c6)
